### PR TITLE
feat: add typed widget values, list box support, css & scroll fixes, and runtime performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,8 @@ dependencies = [
  "regex",
  "resvg",
  "rfd",
+ "serde",
+ "serde_json",
  "unic-langid",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,12 @@ package = "properties"
 version = "0.1.1"
 optional = true
 
+[dependencies.serde]
+version = "1"
+
+[dependencies.serde_json]
+version = "1"
+
 [dependencies.libsqlite3-sys]
 version = "0.30.1"
 features = ["bundled"]

--- a/crates/local-examples/Cargo.lock
+++ b/crates/local-examples/Cargo.lock
@@ -862,6 +862,8 @@ dependencies = [
  "regex",
  "resvg",
  "rfd",
+ "serde",
+ "serde_json",
  "unic-langid",
 ]
 

--- a/crates/local-examples/README.md
+++ b/crates/local-examples/README.md
@@ -2,6 +2,12 @@
 
 This crate is intentionally local-only and not part of the root workspace.
 
+Includes examples:
+
+- `typed_values_example` — ChoiceBox/RadioButton typed values (i32, bool, enum, object)
+- `theming_provider_example`
+- `widget_overview_example`
+
 Run:
 
 ```bash

--- a/crates/local-examples/README.md
+++ b/crates/local-examples/README.md
@@ -8,8 +8,16 @@ Includes examples:
 - `theming_provider_example`
 - `widget_overview_example`
 
-Run:
+Run the default demo (`widget-overview`):
 
 ```bash
 cargo run --manifest-path crates/local-examples/Cargo.toml
+```
+
+Run a specific example:
+
+```bash
+cargo run --manifest-path crates/local-examples/Cargo.toml -- theming-provider
+cargo run --manifest-path crates/local-examples/Cargo.toml -- typed-values
+cargo run --manifest-path crates/local-examples/Cargo.toml -- widget-overview
 ```

--- a/crates/local-examples/assets/examples/typed_values.css
+++ b/crates/local-examples/assets/examples/typed_values.css
@@ -1,0 +1,58 @@
+body {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 20px;
+    background-color: #1a1a2e;
+}
+
+.page-head {
+    margin-bottom: 24px;
+}
+
+.page-head h3 {
+    color: #e0e0ff;
+    font-size: 22px;
+    margin-bottom: 4px;
+}
+
+.page-head p {
+    color: #8888aa;
+    font-size: 13px;
+}
+
+.demo-grid {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.demo-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #252540;
+    border-radius: 8px;
+    padding: 16px;
+    width: 240px;
+}
+
+.demo-card h5 {
+    color: #c0c0f0;
+    font-size: 14px;
+    margin-bottom: 2px;
+}
+
+.demo-card p {
+    color: #8888aa;
+    font-size: 12px;
+}
+
+.result-label {
+    color: #66ff99;
+    font-size: 12px;
+    padding: 6px 8px;
+    background-color: #1a1a2e;
+    border-radius: 4px;
+}

--- a/crates/local-examples/assets/examples/typed_values.css
+++ b/crates/local-examples/assets/examples/typed_values.css
@@ -1,58 +1,87 @@
 body {
+    width: 100%;
+    height: 100%;
     display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
     flex-direction: column;
-    align-items: stretch;
-    padding: 20px;
-    background-color: #1a1a2e;
+    gap: 18px;
+    padding: 24px;
+    background: #141723;
+    overflow-y: scroll;
+    overflow-x: hidden;
 }
 
 .page-head {
-    margin-bottom: 24px;
+    width: 100%;
+    min-height: 60px;
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
 }
 
-.page-head h3 {
-    color: #e0e0ff;
-    font-size: 22px;
-    margin-bottom: 4px;
+.page-head > h3 {
+    margin: 0;
+    color: #f5f7ff;
 }
 
-.page-head p {
-    color: #8888aa;
+.page-head > p {
+    margin: 0;
+    color: #b8bfd6;
     font-size: 13px;
 }
 
 .demo-grid {
+    width: 100%;
     display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 16px;
+    gap: 14px;
 }
 
 .demo-card {
+    position: relative;
+    width: 240px;
+    min-height: 180px;
+    padding: 16px;
+    border-radius: 12px;
+    border: 2px #2f3750;
+    background: #1f2636;
     display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
     flex-direction: column;
     gap: 10px;
-    background-color: #252540;
-    border-radius: 8px;
-    padding: 16px;
-    width: 240px;
 }
 
-.demo-card h5 {
-    color: #c0c0f0;
-    font-size: 14px;
-    margin-bottom: 2px;
+.demo-card > h5 {
+    margin: 0;
+    color: #f2f4ff;
 }
 
-.demo-card p {
-    color: #8888aa;
-    font-size: 12px;
+.-card > p {
+    margin: 0;
+}
+
+.demo-card > select,
+.demo-card > fieldset {
+    width: 100%;
+}
+
+.demo-card > fieldset {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .result-label {
     color: #66ff99;
     font-size: 12px;
     padding: 6px 8px;
-    background-color: #1a1a2e;
-    border-radius: 4px;
 }

--- a/crates/local-examples/assets/examples/typed_values.html
+++ b/crates/local-examples/assets/examples/typed_values.html
@@ -13,7 +13,7 @@
 
   <!-- ChoiceBox: integer values -->
   <div class="demo-card">
-    <h5>ChoiceBox — Integer</h5>
+    <h5>ChoiceBox - Integer</h5>
     <p>Priority score (i32)</p>
     <select id="choice-int" onchange="on_choice_int_change">
       <option value="10"  internal-value-type="i32">Low (10)</option>
@@ -25,7 +25,7 @@
 
   <!-- ChoiceBox: boolean values -->
   <div class="demo-card">
-    <h5>ChoiceBox — Boolean</h5>
+    <h5>ChoiceBox - Boolean</h5>
     <p>Feature toggle (bool)</p>
     <select id="choice-bool" onchange="on_choice_bool_change">
       <option value="true"  internal-value-type="bool" selected>Enabled</option>
@@ -36,7 +36,7 @@
 
   <!-- ChoiceBox: enum-like string values (Rust side maps to enum) -->
   <div class="demo-card">
-    <h5>ChoiceBox — Enum</h5>
+    <h5>ChoiceBox - Enum</h5>
     <p>Direction (string→enum)</p>
     <select id="choice-enum" onchange="on_choice_enum_change">
       <option value="North" selected>North</option>
@@ -49,20 +49,20 @@
 
   <!-- ChoiceBox: object (f32 pair stored as two-field struct via Arc) -->
   <div class="demo-card">
-    <h5>ChoiceBox — Object</h5>
+    <h5>ChoiceBox - Object</h5>
     <p>Resolution (custom struct)</p>
     <select id="choice-obj" onchange="on_choice_obj_change">
-      <option value="1280x720"  selected>HD (1280×720)</option>
-      <option value="1920x1080">Full HD (1920×1080)</option>
-      <option value="2560x1440">2K (2560×1440)</option>
-      <option value="3840x2160">4K (3840×2160)</option>
+      <option value="1280x720"  selected>HD (1280x720)</option>
+      <option value="1920x1080">Full HD (1920x1080)</option>
+      <option value="2560x1440">2K (2560x1440)</option>
+      <option value="3840x2160">4K (3840x2160)</option>
     </select>
-    <p id="choice-obj-result" class="result-label">Selected: 1280×720</p>
+    <p id="choice-obj-result" class="result-label">Selected: 1280x720</p>
   </div>
 
   <!-- RadioButton: integer values -->
   <div class="demo-card">
-    <h5>RadioButton — Integer</h5>
+    <h5>RadioButton - Integer</h5>
     <p>Volume level (u32)</p>
     <fieldset id="radio-int" onchange="on_radio_int_change">
       <radio value="0"   internal-value-type="u32">Mute (0)</radio>
@@ -75,7 +75,7 @@
 
   <!-- RadioButton: boolean values -->
   <div class="demo-card">
-    <h5>RadioButton — Boolean</h5>
+    <h5>RadioButton - Boolean</h5>
     <p>Notifications (bool)</p>
     <fieldset id="radio-bool" onchange="on_radio_bool_change">
       <radio value="true"  internal-value-type="bool" selected>On</radio>
@@ -86,7 +86,7 @@
 
   <!-- RadioButton: enum-like string values -->
   <div class="demo-card">
-    <h5>RadioButton — Enum</h5>
+    <h5>RadioButton - Enum</h5>
     <p>Theme (string→enum)</p>
     <fieldset id="radio-enum" onchange="on_radio_enum_change">
       <radio value="Light" selected>Light</radio>
@@ -98,7 +98,7 @@
 
   <!-- RadioButton: f32 object values -->
   <div class="demo-card">
-    <h5>RadioButton — Object</h5>
+    <h5>RadioButton - Object</h5>
     <p>Scale factor (f32)</p>
     <fieldset id="radio-obj" onchange="on_radio_obj_change">
       <radio value="0.75" internal-value-type="f32" selected>75%</radio>

--- a/crates/local-examples/assets/examples/typed_values.html
+++ b/crates/local-examples/assets/examples/typed_values.html
@@ -1,0 +1,114 @@
+<html>
+<head>
+  <meta name="typed-values-demo" />
+  <link rel="stylesheet" href="typed_values.css" />
+</head>
+<body>
+<div class="page-head">
+  <h3>Typed Values Demo</h3>
+  <p>ChoiceBox and RadioButton with integer, boolean, enum, and object values</p>
+</div>
+
+<div class="demo-grid">
+
+  <!-- ChoiceBox: integer values -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Integer</h5>
+    <p>Priority score (i32)</p>
+    <select id="choice-int" onchange="on_choice_int_change">
+      <option value="10"  internal-value-type="i32">Low (10)</option>
+      <option value="50"  internal-value-type="i32" selected>Medium (50)</option>
+      <option value="100" internal-value-type="i32">High (100)</option>
+    </select>
+    <p id="choice-int-result" class="result-label">Selected: 50</p>
+  </div>
+
+  <!-- ChoiceBox: boolean values -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Boolean</h5>
+    <p>Feature toggle (bool)</p>
+    <select id="choice-bool" onchange="on_choice_bool_change">
+      <option value="true"  internal-value-type="bool" selected>Enabled</option>
+      <option value="false" internal-value-type="bool">Disabled</option>
+    </select>
+    <p id="choice-bool-result" class="result-label">Selected: true</p>
+  </div>
+
+  <!-- ChoiceBox: enum-like string values (Rust side maps to enum) -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Enum</h5>
+    <p>Direction (string→enum)</p>
+    <select id="choice-enum" onchange="on_choice_enum_change">
+      <option value="North" selected>North</option>
+      <option value="South">South</option>
+      <option value="East">East</option>
+      <option value="West">West</option>
+    </select>
+    <p id="choice-enum-result" class="result-label">Selected: North</p>
+  </div>
+
+  <!-- ChoiceBox: object (f32 pair stored as two-field struct via Arc) -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Object</h5>
+    <p>Resolution (custom struct)</p>
+    <select id="choice-obj" onchange="on_choice_obj_change">
+      <option value="1280x720"  selected>HD (1280×720)</option>
+      <option value="1920x1080">Full HD (1920×1080)</option>
+      <option value="2560x1440">2K (2560×1440)</option>
+      <option value="3840x2160">4K (3840×2160)</option>
+    </select>
+    <p id="choice-obj-result" class="result-label">Selected: 1280×720</p>
+  </div>
+
+  <!-- RadioButton: integer values -->
+  <div class="demo-card">
+    <h5>RadioButton — Integer</h5>
+    <p>Volume level (u32)</p>
+    <fieldset id="radio-int" onchange="on_radio_int_change">
+      <radio value="0"   internal-value-type="u32">Mute (0)</radio>
+      <radio value="25"  internal-value-type="u32" selected>Low (25)</radio>
+      <radio value="75"  internal-value-type="u32">High (75)</radio>
+      <radio value="100" internal-value-type="u32">Max (100)</radio>
+    </fieldset>
+    <p id="radio-int-result" class="result-label">Selected: 25</p>
+  </div>
+
+  <!-- RadioButton: boolean values -->
+  <div class="demo-card">
+    <h5>RadioButton — Boolean</h5>
+    <p>Notifications (bool)</p>
+    <fieldset id="radio-bool" onchange="on_radio_bool_change">
+      <radio value="true"  internal-value-type="bool" selected>On</radio>
+      <radio value="false" internal-value-type="bool">Off</radio>
+    </fieldset>
+    <p id="radio-bool-result" class="result-label">Selected: true</p>
+  </div>
+
+  <!-- RadioButton: enum-like string values -->
+  <div class="demo-card">
+    <h5>RadioButton — Enum</h5>
+    <p>Theme (string→enum)</p>
+    <fieldset id="radio-enum" onchange="on_radio_enum_change">
+      <radio value="Light" selected>Light</radio>
+      <radio value="Dark">Dark</radio>
+      <radio value="System">System</radio>
+    </fieldset>
+    <p id="radio-enum-result" class="result-label">Selected: Light</p>
+  </div>
+
+  <!-- RadioButton: f32 object values -->
+  <div class="demo-card">
+    <h5>RadioButton — Object</h5>
+    <p>Scale factor (f32)</p>
+    <fieldset id="radio-obj" onchange="on_radio_obj_change">
+      <radio value="0.75" internal-value-type="f32" selected>75%</radio>
+      <radio value="1.0"  internal-value-type="f32">100%</radio>
+      <radio value="1.5"  internal-value-type="f32">150%</radio>
+      <radio value="2.0"  internal-value-type="f32">200%</radio>
+    </fieldset>
+    <p id="radio-obj-result" class="result-label">Selected: 0.75</p>
+  </div>
+
+</div>
+</body>
+</html>

--- a/crates/local-examples/assets/examples/widget_overview.css
+++ b/crates/local-examples/assets/examples/widget_overview.css
@@ -275,7 +275,7 @@ dialog.dialog-renderer-bevy-app.dialog-type-error > .dialog-panel {
 
 .text-transform-lower {
     color: #c4ffd1;
-    text-transfrom: lowercase;
+    text-transform: lowercase;
 }
 
 .text-transform-cap {

--- a/crates/local-examples/assets/examples/widgets_overview.html
+++ b/crates/local-examples/assets/examples/widgets_overview.html
@@ -49,6 +49,28 @@
   </div>
 
   <div class="widget-card">
+    <h5>ListBox (Single)</h5>
+    <listbox>
+      <option value="a" selected>Option A</option>
+      <option value="b">Option B</option>
+      <option value="c">Option C</option>
+      <option value="d">Option D</option>
+      <option value="e">Option E</option>
+    </listbox>
+  </div>
+
+  <div class="widget-card">
+    <h5>ListBox (Multi)</h5>
+    <listbox multiselect>
+      <option value="rock" selected>Rock</option>
+      <option value="jazz" selected>Jazz</option>
+      <option value="pop">Pop</option>
+      <option value="electro">Electro</option>
+      <option value="blues">Blues</option>
+    </listbox>
+  </div>
+
+  <div class="widget-card">
     <h5>ColorPicker</h5>
     <colorpicker value="#4b7cff"></colorpicker>
   </div>

--- a/crates/local-examples/src/main.rs
+++ b/crates/local-examples/src/main.rs
@@ -4,7 +4,7 @@ mod widget_overview_example;
 
 fn main() {
     configure_linux_window_backend();
-    widget_overview_example::run();
+    typed_values_example::run();
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/local-examples/src/main.rs
+++ b/crates/local-examples/src/main.rs
@@ -1,9 +1,10 @@
 mod theming_provider_example;
+mod typed_values_example;
 mod widget_overview_example;
 
 fn main() {
     configure_linux_window_backend();
-    widget_overview_example::run();
+    typed_values_example::run();
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/local-examples/src/main.rs
+++ b/crates/local-examples/src/main.rs
@@ -4,7 +4,42 @@ mod widget_overview_example;
 
 fn main() {
     configure_linux_window_backend();
-    widget_overview_example::run();
+
+    let mut args = std::env::args();
+    let program = args.next().unwrap_or_else(|| "local-examples".to_string());
+
+    match args.next().as_deref() {
+        None => widget_overview_example::run(),
+        Some("--help" | "-h" | "help") => print_usage(&program),
+        Some(selection) if run_example(selection) => {}
+        Some(selection) => {
+            eprintln!("Unknown example: {selection}\n");
+            print_usage(&program);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run_example(selection: &str) -> bool {
+    match selection {
+        "widget_overview_example" | "widget-overview" | "widget" => {
+            widget_overview_example::run();
+            true
+        }
+        "theming_provider_example" | "theming-provider" | "theme" => {
+            theming_provider_example::run();
+            true
+        }
+        "typed_values_example" | "typed-values" | "typed" => {
+            typed_values_example::run();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn print_usage(program: &str) {
+    eprintln!("Usage: {program} [widget-overview|theming-provider|typed-values]");
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/local-examples/src/main.rs
+++ b/crates/local-examples/src/main.rs
@@ -4,7 +4,7 @@ mod widget_overview_example;
 
 fn main() {
     configure_linux_window_backend();
-    typed_values_example::run();
+    widget_overview_example::run();
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/local-examples/src/typed_values_example.rs
+++ b/crates/local-examples/src/typed_values_example.rs
@@ -167,7 +167,7 @@ fn on_choice_obj_change(
     };
 
     let text = match cb.value.value_as_str().and_then(Resolution::from_str) {
-        Some(res) => format!("Selected: {}×{} (Resolution)", res.width, res.height),
+        Some(res) => format!("Selected: {}x{} (Resolution)", res.width, res.height),
         None => format!("Selected: {}", cb.value.text),
     };
     set_result("choice-obj-result", text, &mut paragraph_q);

--- a/crates/local-examples/src/typed_values_example.rs
+++ b/crates/local-examples/src/typed_values_example.rs
@@ -1,0 +1,296 @@
+/// Example demonstrating typed values on ChoiceBox and RadioButton widgets.
+///
+/// Shows how integer, boolean, enum-like string, and struct/f32 values are
+/// stored inside `Arc<dyn Any + Send + Sync>` and recovered at runtime via
+/// `get_value::<T>()` / `value_as_str()`.
+use bevy::prelude::*;
+use bevy_extended_ui::html::{HtmlChange, HtmlSource};
+use bevy_extended_ui::io::HtmlAsset;
+use bevy_extended_ui::registry::UiRegistry;
+use bevy_extended_ui::styles::CssID;
+use bevy_extended_ui::widgets::{ChoiceBox, FieldSelectionSingle, Paragraph, RadioButton};
+use bevy_extended_ui::{ExtendedCam, ExtendedUiConfiguration, ExtendedUiPlugin};
+use bevy_extended_ui_macros::html_fn;
+
+// ---------------------------------------------------------------------------
+// Application entry point
+// ---------------------------------------------------------------------------
+
+pub fn run() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(ExtendedUiPlugin)
+        .add_systems(Startup, (configure_ui, load_ui))
+        .run();
+}
+
+fn configure_ui(mut config: ResMut<ExtendedUiConfiguration>) {
+    config.camera = ExtendedCam::Default;
+}
+
+fn load_ui(mut reg: ResMut<UiRegistry>, asset_server: Res<AssetServer>) {
+    let handle: Handle<HtmlAsset> = asset_server.load("examples/typed_values.html");
+    reg.add_and_use(
+        "typed-values-demo".to_string(),
+        HtmlSource::from_handle(handle),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helper – write a string to a result label by CssID
+// ---------------------------------------------------------------------------
+
+fn set_result(
+    id: &str,
+    text: String,
+    paragraph_q: &mut Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    for (mut p, css_id) in paragraph_q.iter_mut() {
+        if css_id.0 == id {
+            p.text = text;
+            return;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — integer (i32)
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_choice_int_change")]
+fn on_choice_int_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.get_value::<i32>() {
+        Some(n) => format!("Selected: {} (i32)", n),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-int-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — boolean
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_choice_bool_change")]
+fn on_choice_bool_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.get_value::<bool>() {
+        Some(b) => format!("Selected: {} (bool)", b),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-bool-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — enum-like (plain String, mapped to Direction on Rust side)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum Direction {
+    North,
+    South,
+    East,
+    West,
+}
+
+impl Direction {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "North" => Some(Self::North),
+            "South" => Some(Self::South),
+            "East" => Some(Self::East),
+            "West" => Some(Self::West),
+            _ => None,
+        }
+    }
+}
+
+#[html_fn("on_choice_enum_change")]
+fn on_choice_enum_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.value_as_str().and_then(Direction::from_str) {
+        Some(dir) => format!("Selected: {:?} (Direction)", dir),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-enum-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — object (resolution stored as plain String, parsed to struct)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct Resolution {
+    width: u32,
+    height: u32,
+}
+
+impl Resolution {
+    fn from_str(s: &str) -> Option<Self> {
+        let (w, h) = s.split_once('x')?;
+        Some(Self {
+            width: w.parse().ok()?,
+            height: h.parse().ok()?,
+        })
+    }
+}
+
+#[html_fn("on_choice_obj_change")]
+fn on_choice_obj_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.value_as_str().and_then(Resolution::from_str) {
+        Some(res) => format!("Selected: {}×{} (Resolution)", res.width, res.height),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-obj-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — integer (u32)  — fieldset emits HtmlChange on the FieldSet entity
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_radio_int_change")]
+fn on_radio_int_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.get_value::<u32>() {
+        Some(n) => format!("Selected: {} (u32)", n),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-int-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — boolean
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_radio_bool_change")]
+fn on_radio_bool_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.get_value::<bool>() {
+        Some(b) => format!("Selected: {} (bool)", b),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-bool-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — enum-like (Theme, mapped from String)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum Theme {
+    Light,
+    Dark,
+    System,
+}
+
+impl Theme {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "Light" => Some(Self::Light),
+            "Dark" => Some(Self::Dark),
+            "System" => Some(Self::System),
+            _ => None,
+        }
+    }
+}
+
+#[html_fn("on_radio_enum_change")]
+fn on_radio_enum_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.value_as_str().and_then(Theme::from_str) {
+        Some(theme) => format!("Selected: {:?} (Theme)", theme),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-enum-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — object (f32 scale factor)
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_radio_obj_change")]
+fn on_radio_obj_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.get_value::<f32>() {
+        Some(scale) => format!("Selected: {:.2}x (f32)", scale),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-obj-result", text, &mut paragraph_q);
+}

--- a/crates/local-wasm-examples/Cargo.lock
+++ b/crates/local-wasm-examples/Cargo.lock
@@ -859,6 +859,8 @@ dependencies = [
  "regex",
  "resvg",
  "rfd",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/crates/local-wasm-examples/Cargo.toml
+++ b/crates/local-wasm-examples/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 default = ["theme-provider"]
 theme-provider = []
 widget-overview = []
+typed-values = []
 
 [dependencies]
 bevy = "0.18.1"

--- a/crates/local-wasm-examples/README.md
+++ b/crates/local-wasm-examples/README.md
@@ -29,3 +29,4 @@ cargo run --manifest-path crates/local-wasm-examples/Cargo.toml
 
 - `theming_provider_example` (default feature: `theme-provider`)
 - `widget_overview_example` (feature: `widget-overview`)
+- `typed_values_example` (feature: `typed-values`) — ChoiceBox/RadioButton typed values (i32, bool, enum, object)

--- a/crates/local-wasm-examples/assets/examples/typed_values.css
+++ b/crates/local-wasm-examples/assets/examples/typed_values.css
@@ -1,0 +1,58 @@
+body {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 20px;
+    background-color: #1a1a2e;
+}
+
+.page-head {
+    margin-bottom: 24px;
+}
+
+.page-head h3 {
+    color: #e0e0ff;
+    font-size: 22px;
+    margin-bottom: 4px;
+}
+
+.page-head p {
+    color: #8888aa;
+    font-size: 13px;
+}
+
+.demo-grid {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.demo-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #252540;
+    border-radius: 8px;
+    padding: 16px;
+    width: 240px;
+}
+
+.demo-card h5 {
+    color: #c0c0f0;
+    font-size: 14px;
+    margin-bottom: 2px;
+}
+
+.demo-card p {
+    color: #8888aa;
+    font-size: 12px;
+}
+
+.result-label {
+    color: #66ff99;
+    font-size: 12px;
+    padding: 6px 8px;
+    background-color: #1a1a2e;
+    border-radius: 4px;
+}

--- a/crates/local-wasm-examples/assets/examples/typed_values.css
+++ b/crates/local-wasm-examples/assets/examples/typed_values.css
@@ -1,58 +1,87 @@
 body {
+    width: 100%;
+    height: 100%;
     display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
     flex-direction: column;
-    align-items: stretch;
-    padding: 20px;
-    background-color: #1a1a2e;
+    gap: 18px;
+    padding: 24px;
+    background: #141723;
+    overflow-y: scroll;
+    overflow-x: hidden;
 }
 
 .page-head {
-    margin-bottom: 24px;
+    width: 100%;
+    min-height: 60px;
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
 }
 
-.page-head h3 {
-    color: #e0e0ff;
-    font-size: 22px;
-    margin-bottom: 4px;
+.page-head > h3 {
+    margin: 0;
+    color: #f5f7ff;
 }
 
-.page-head p {
-    color: #8888aa;
+.page-head > p {
+    margin: 0;
+    color: #b8bfd6;
     font-size: 13px;
 }
 
 .demo-grid {
+    width: 100%;
     display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 16px;
+    gap: 14px;
 }
 
 .demo-card {
+    position: relative;
+    width: 240px;
+    min-height: 180px;
+    padding: 16px;
+    border-radius: 12px;
+    border: 2px #2f3750;
+    background: #1f2636;
     display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
     flex-direction: column;
     gap: 10px;
-    background-color: #252540;
-    border-radius: 8px;
-    padding: 16px;
-    width: 240px;
 }
 
-.demo-card h5 {
-    color: #c0c0f0;
-    font-size: 14px;
-    margin-bottom: 2px;
+.demo-card > h5 {
+    margin: 0;
+    color: #f2f4ff;
 }
 
-.demo-card p {
-    color: #8888aa;
-    font-size: 12px;
+.-card > p {
+    margin: 0;
+}
+
+.demo-card > select,
+.demo-card > fieldset {
+    width: 100%;
+}
+
+.demo-card > fieldset {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .result-label {
     color: #66ff99;
     font-size: 12px;
     padding: 6px 8px;
-    background-color: #1a1a2e;
-    border-radius: 4px;
 }

--- a/crates/local-wasm-examples/assets/examples/typed_values.html
+++ b/crates/local-wasm-examples/assets/examples/typed_values.html
@@ -13,7 +13,7 @@
 
   <!-- ChoiceBox: integer values -->
   <div class="demo-card">
-    <h5>ChoiceBox — Integer</h5>
+    <h5>ChoiceBox - Integer</h5>
     <p>Priority score (i32)</p>
     <select id="choice-int" onchange="on_choice_int_change">
       <option value="10"  internal-value-type="i32">Low (10)</option>
@@ -25,7 +25,7 @@
 
   <!-- ChoiceBox: boolean values -->
   <div class="demo-card">
-    <h5>ChoiceBox — Boolean</h5>
+    <h5>ChoiceBox - Boolean</h5>
     <p>Feature toggle (bool)</p>
     <select id="choice-bool" onchange="on_choice_bool_change">
       <option value="true"  internal-value-type="bool" selected>Enabled</option>
@@ -36,7 +36,7 @@
 
   <!-- ChoiceBox: enum-like string values (Rust side maps to enum) -->
   <div class="demo-card">
-    <h5>ChoiceBox — Enum</h5>
+    <h5>ChoiceBox - Enum</h5>
     <p>Direction (string→enum)</p>
     <select id="choice-enum" onchange="on_choice_enum_change">
       <option value="North" selected>North</option>
@@ -49,20 +49,20 @@
 
   <!-- ChoiceBox: object (f32 pair stored as two-field struct via Arc) -->
   <div class="demo-card">
-    <h5>ChoiceBox — Object</h5>
+    <h5>ChoiceBox - Object</h5>
     <p>Resolution (custom struct)</p>
     <select id="choice-obj" onchange="on_choice_obj_change">
-      <option value="1280x720"  selected>HD (1280×720)</option>
-      <option value="1920x1080">Full HD (1920×1080)</option>
-      <option value="2560x1440">2K (2560×1440)</option>
-      <option value="3840x2160">4K (3840×2160)</option>
+      <option value="1280x720"  selected>HD (1280x720)</option>
+      <option value="1920x1080">Full HD (1920x1080)</option>
+      <option value="2560x1440">2K (2560x1440)</option>
+      <option value="3840x2160">4K (3840x2160)</option>
     </select>
-    <p id="choice-obj-result" class="result-label">Selected: 1280×720</p>
+    <p id="choice-obj-result" class="result-label">Selected: 1280x720</p>
   </div>
 
   <!-- RadioButton: integer values -->
   <div class="demo-card">
-    <h5>RadioButton — Integer</h5>
+    <h5>RadioButton - Integer</h5>
     <p>Volume level (u32)</p>
     <fieldset id="radio-int" onchange="on_radio_int_change">
       <radio value="0"   internal-value-type="u32">Mute (0)</radio>
@@ -75,7 +75,7 @@
 
   <!-- RadioButton: boolean values -->
   <div class="demo-card">
-    <h5>RadioButton — Boolean</h5>
+    <h5>RadioButton - Boolean</h5>
     <p>Notifications (bool)</p>
     <fieldset id="radio-bool" onchange="on_radio_bool_change">
       <radio value="true"  internal-value-type="bool" selected>On</radio>
@@ -86,7 +86,7 @@
 
   <!-- RadioButton: enum-like string values -->
   <div class="demo-card">
-    <h5>RadioButton — Enum</h5>
+    <h5>RadioButton - Enum</h5>
     <p>Theme (string→enum)</p>
     <fieldset id="radio-enum" onchange="on_radio_enum_change">
       <radio value="Light" selected>Light</radio>
@@ -98,7 +98,7 @@
 
   <!-- RadioButton: f32 object values -->
   <div class="demo-card">
-    <h5>RadioButton — Object</h5>
+    <h5>RadioButton - Object</h5>
     <p>Scale factor (f32)</p>
     <fieldset id="radio-obj" onchange="on_radio_obj_change">
       <radio value="0.75" internal-value-type="f32" selected>75%</radio>

--- a/crates/local-wasm-examples/assets/examples/typed_values.html
+++ b/crates/local-wasm-examples/assets/examples/typed_values.html
@@ -1,0 +1,114 @@
+<html>
+<head>
+  <meta name="typed-values-demo" />
+  <link rel="stylesheet" href="typed_values.css" />
+</head>
+<body>
+<div class="page-head">
+  <h3>Typed Values Demo</h3>
+  <p>ChoiceBox and RadioButton with integer, boolean, enum, and object values</p>
+</div>
+
+<div class="demo-grid">
+
+  <!-- ChoiceBox: integer values -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Integer</h5>
+    <p>Priority score (i32)</p>
+    <select id="choice-int" onchange="on_choice_int_change">
+      <option value="10"  internal-value-type="i32">Low (10)</option>
+      <option value="50"  internal-value-type="i32" selected>Medium (50)</option>
+      <option value="100" internal-value-type="i32">High (100)</option>
+    </select>
+    <p id="choice-int-result" class="result-label">Selected: 50</p>
+  </div>
+
+  <!-- ChoiceBox: boolean values -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Boolean</h5>
+    <p>Feature toggle (bool)</p>
+    <select id="choice-bool" onchange="on_choice_bool_change">
+      <option value="true"  internal-value-type="bool" selected>Enabled</option>
+      <option value="false" internal-value-type="bool">Disabled</option>
+    </select>
+    <p id="choice-bool-result" class="result-label">Selected: true</p>
+  </div>
+
+  <!-- ChoiceBox: enum-like string values (Rust side maps to enum) -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Enum</h5>
+    <p>Direction (string→enum)</p>
+    <select id="choice-enum" onchange="on_choice_enum_change">
+      <option value="North" selected>North</option>
+      <option value="South">South</option>
+      <option value="East">East</option>
+      <option value="West">West</option>
+    </select>
+    <p id="choice-enum-result" class="result-label">Selected: North</p>
+  </div>
+
+  <!-- ChoiceBox: object (f32 pair stored as two-field struct via Arc) -->
+  <div class="demo-card">
+    <h5>ChoiceBox — Object</h5>
+    <p>Resolution (custom struct)</p>
+    <select id="choice-obj" onchange="on_choice_obj_change">
+      <option value="1280x720"  selected>HD (1280×720)</option>
+      <option value="1920x1080">Full HD (1920×1080)</option>
+      <option value="2560x1440">2K (2560×1440)</option>
+      <option value="3840x2160">4K (3840×2160)</option>
+    </select>
+    <p id="choice-obj-result" class="result-label">Selected: 1280×720</p>
+  </div>
+
+  <!-- RadioButton: integer values -->
+  <div class="demo-card">
+    <h5>RadioButton — Integer</h5>
+    <p>Volume level (u32)</p>
+    <fieldset id="radio-int" onchange="on_radio_int_change">
+      <radio value="0"   internal-value-type="u32">Mute (0)</radio>
+      <radio value="25"  internal-value-type="u32" selected>Low (25)</radio>
+      <radio value="75"  internal-value-type="u32">High (75)</radio>
+      <radio value="100" internal-value-type="u32">Max (100)</radio>
+    </fieldset>
+    <p id="radio-int-result" class="result-label">Selected: 25</p>
+  </div>
+
+  <!-- RadioButton: boolean values -->
+  <div class="demo-card">
+    <h5>RadioButton — Boolean</h5>
+    <p>Notifications (bool)</p>
+    <fieldset id="radio-bool" onchange="on_radio_bool_change">
+      <radio value="true"  internal-value-type="bool" selected>On</radio>
+      <radio value="false" internal-value-type="bool">Off</radio>
+    </fieldset>
+    <p id="radio-bool-result" class="result-label">Selected: true</p>
+  </div>
+
+  <!-- RadioButton: enum-like string values -->
+  <div class="demo-card">
+    <h5>RadioButton — Enum</h5>
+    <p>Theme (string→enum)</p>
+    <fieldset id="radio-enum" onchange="on_radio_enum_change">
+      <radio value="Light" selected>Light</radio>
+      <radio value="Dark">Dark</radio>
+      <radio value="System">System</radio>
+    </fieldset>
+    <p id="radio-enum-result" class="result-label">Selected: Light</p>
+  </div>
+
+  <!-- RadioButton: f32 object values -->
+  <div class="demo-card">
+    <h5>RadioButton — Object</h5>
+    <p>Scale factor (f32)</p>
+    <fieldset id="radio-obj" onchange="on_radio_obj_change">
+      <radio value="0.75" internal-value-type="f32" selected>75%</radio>
+      <radio value="1.0"  internal-value-type="f32">100%</radio>
+      <radio value="1.5"  internal-value-type="f32">150%</radio>
+      <radio value="2.0"  internal-value-type="f32">200%</radio>
+    </fieldset>
+    <p id="radio-obj-result" class="result-label">Selected: 0.75</p>
+  </div>
+
+</div>
+</body>
+</html>

--- a/crates/local-wasm-examples/assets/examples/widgets_overview.html
+++ b/crates/local-wasm-examples/assets/examples/widgets_overview.html
@@ -49,6 +49,28 @@
   </div>
 
   <div class="widget-card">
+    <h5>ListBox (Single)</h5>
+    <listbox>
+      <option value="a" selected>Option A</option>
+      <option value="b">Option B</option>
+      <option value="c">Option C</option>
+      <option value="d">Option D</option>
+      <option value="e">Option E</option>
+    </listbox>
+  </div>
+
+  <div class="widget-card">
+    <h5>ListBox (Multi)</h5>
+    <listbox multiselect>
+      <option value="rock" selected>Rock</option>
+      <option value="jazz" selected>Jazz</option>
+      <option value="pop">Pop</option>
+      <option value="electro">Electro</option>
+      <option value="blues">Blues</option>
+    </listbox>
+  </div>
+
+  <div class="widget-card">
     <h5>ColorPicker</h5>
     <colorpicker value="#4b7cff"></colorpicker>
   </div>

--- a/crates/local-wasm-examples/src/main.rs
+++ b/crates/local-wasm-examples/src/main.rs
@@ -1,17 +1,23 @@
 #[cfg(feature = "theme-provider")]
 mod theming_provider_example;
+#[cfg(feature = "typed-values")]
+mod typed_values_example;
 #[cfg(feature = "widget-overview")]
 mod widget_overview_example;
 
 fn main() {
-    #[cfg(all(feature = "theme-provider", feature = "widget-overview"))]
+    #[cfg(any(
+        all(feature = "theme-provider", feature = "widget-overview"),
+        all(feature = "theme-provider", feature = "typed-values"),
+        all(feature = "widget-overview", feature = "typed-values"),
+    ))]
     compile_error!(
-        "Select exactly one demo feature for local-wasm-examples: `theme-provider` or `widget-overview`."
+        "Select exactly one demo feature for local-wasm-examples: `theme-provider`, `widget-overview`, or `typed-values`."
     );
 
-    #[cfg(not(any(feature = "theme-provider", feature = "widget-overview")))]
+    #[cfg(not(any(feature = "theme-provider", feature = "widget-overview", feature = "typed-values")))]
     compile_error!(
-        "Enable one demo feature for local-wasm-examples: `theme-provider` or `widget-overview`."
+        "Enable one demo feature for local-wasm-examples: `theme-provider`, `widget-overview`, or `typed-values`."
     );
 
     #[cfg(feature = "theme-provider")]
@@ -19,4 +25,7 @@ fn main() {
 
     #[cfg(feature = "widget-overview")]
     widget_overview_example::run();
+
+    #[cfg(feature = "typed-values")]
+    typed_values_example::run();
 }

--- a/crates/local-wasm-examples/src/typed_values_example.rs
+++ b/crates/local-wasm-examples/src/typed_values_example.rs
@@ -1,0 +1,296 @@
+/// Example demonstrating typed values on ChoiceBox and RadioButton widgets.
+///
+/// Shows how integer, boolean, enum-like string, and struct/f32 values are
+/// stored inside `Arc<dyn Any + Send + Sync>` and recovered at runtime via
+/// `get_value::<T>()` / `value_as_str()`.
+use bevy::prelude::*;
+use bevy_extended_ui::html::{HtmlChange, HtmlSource};
+use bevy_extended_ui::io::HtmlAsset;
+use bevy_extended_ui::registry::UiRegistry;
+use bevy_extended_ui::styles::CssID;
+use bevy_extended_ui::widgets::{ChoiceBox, FieldSelectionSingle, Paragraph, RadioButton};
+use bevy_extended_ui::{ExtendedCam, ExtendedUiConfiguration, ExtendedUiPlugin};
+use bevy_extended_ui_macros::html_fn;
+
+// ---------------------------------------------------------------------------
+// Application entry point
+// ---------------------------------------------------------------------------
+
+pub fn run() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(ExtendedUiPlugin)
+        .add_systems(Startup, (configure_ui, load_ui))
+        .run();
+}
+
+fn configure_ui(mut config: ResMut<ExtendedUiConfiguration>) {
+    config.camera = ExtendedCam::Default;
+}
+
+fn load_ui(mut reg: ResMut<UiRegistry>, asset_server: Res<AssetServer>) {
+    let handle: Handle<HtmlAsset> = asset_server.load("examples/typed_values.html");
+    reg.add_and_use(
+        "typed-values-demo".to_string(),
+        HtmlSource::from_handle(handle),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helper – write a string to a result label by CssID
+// ---------------------------------------------------------------------------
+
+fn set_result(
+    id: &str,
+    text: String,
+    paragraph_q: &mut Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    for (mut p, css_id) in paragraph_q.iter_mut() {
+        if css_id.0 == id {
+            p.text = text;
+            return;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — integer (i32)
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_choice_int_change")]
+fn on_choice_int_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.get_value::<i32>() {
+        Some(n) => format!("Selected: {} (i32)", n),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-int-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — boolean
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_choice_bool_change")]
+fn on_choice_bool_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.get_value::<bool>() {
+        Some(b) => format!("Selected: {} (bool)", b),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-bool-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — enum-like (plain String, mapped to Direction on Rust side)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum Direction {
+    North,
+    South,
+    East,
+    West,
+}
+
+impl Direction {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "North" => Some(Self::North),
+            "South" => Some(Self::South),
+            "East" => Some(Self::East),
+            "West" => Some(Self::West),
+            _ => None,
+        }
+    }
+}
+
+#[html_fn("on_choice_enum_change")]
+fn on_choice_enum_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.value_as_str().and_then(Direction::from_str) {
+        Some(dir) => format!("Selected: {:?} (Direction)", dir),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-enum-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// ChoiceBox — object (resolution stored as plain String, parsed to struct)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct Resolution {
+    width: u32,
+    height: u32,
+}
+
+impl Resolution {
+    fn from_str(s: &str) -> Option<Self> {
+        let (w, h) = s.split_once('x')?;
+        Some(Self {
+            width: w.parse().ok()?,
+            height: h.parse().ok()?,
+        })
+    }
+}
+
+#[html_fn("on_choice_obj_change")]
+fn on_choice_obj_change(
+    In(event): In<HtmlChange>,
+    choice_q: Query<&ChoiceBox>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(cb) = choice_q.get(event.entity) else {
+        return;
+    };
+
+    let text = match cb.value.value_as_str().and_then(Resolution::from_str) {
+        Some(res) => format!("Selected: {}×{} (Resolution)", res.width, res.height),
+        None => format!("Selected: {}", cb.value.text),
+    };
+    set_result("choice-obj-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — integer (u32)  — fieldset emits HtmlChange on the FieldSet entity
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_radio_int_change")]
+fn on_radio_int_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.get_value::<u32>() {
+        Some(n) => format!("Selected: {} (u32)", n),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-int-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — boolean
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_radio_bool_change")]
+fn on_radio_bool_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.get_value::<bool>() {
+        Some(b) => format!("Selected: {} (bool)", b),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-bool-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — enum-like (Theme, mapped from String)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum Theme {
+    Light,
+    Dark,
+    System,
+}
+
+impl Theme {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "Light" => Some(Self::Light),
+            "Dark" => Some(Self::Dark),
+            "System" => Some(Self::System),
+            _ => None,
+        }
+    }
+}
+
+#[html_fn("on_radio_enum_change")]
+fn on_radio_enum_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.value_as_str().and_then(Theme::from_str) {
+        Some(theme) => format!("Selected: {:?} (Theme)", theme),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-enum-result", text, &mut paragraph_q);
+}
+
+// ---------------------------------------------------------------------------
+// RadioButton — object (f32 scale factor)
+// ---------------------------------------------------------------------------
+
+#[html_fn("on_radio_obj_change")]
+fn on_radio_obj_change(
+    In(event): In<HtmlChange>,
+    selection_q: Query<&FieldSelectionSingle>,
+    radio_q: Query<&RadioButton>,
+    mut paragraph_q: Query<(&mut Paragraph, &CssID), With<Paragraph>>,
+) {
+    let Ok(sel) = selection_q.get(event.entity) else {
+        return;
+    };
+    let Some(radio_entity) = sel.0 else { return };
+    let Ok(rb) = radio_q.get(radio_entity) else {
+        return;
+    };
+
+    let text = match rb.get_value::<f32>() {
+        Some(scale) => format!("Selected: {:.2}x (f32)", scale),
+        None => format!("Selected: {}", rb.label),
+    };
+    set_result("radio-obj-result", text, &mut paragraph_q);
+}

--- a/crates/local-wasm-examples/src/typed_values_example.rs
+++ b/crates/local-wasm-examples/src/typed_values_example.rs
@@ -54,7 +54,7 @@ fn set_result(
 }
 
 // ---------------------------------------------------------------------------
-// ChoiceBox — integer (i32)
+// ChoiceBox - integer (i32)
 // ---------------------------------------------------------------------------
 
 #[html_fn("on_choice_int_change")]
@@ -75,7 +75,7 @@ fn on_choice_int_change(
 }
 
 // ---------------------------------------------------------------------------
-// ChoiceBox — boolean
+// ChoiceBox - boolean
 // ---------------------------------------------------------------------------
 
 #[html_fn("on_choice_bool_change")]
@@ -96,7 +96,7 @@ fn on_choice_bool_change(
 }
 
 // ---------------------------------------------------------------------------
-// ChoiceBox — enum-like (plain String, mapped to Direction on Rust side)
+// ChoiceBox - enum-like (plain String, mapped to Direction on Rust side)
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
@@ -137,7 +137,7 @@ fn on_choice_enum_change(
 }
 
 // ---------------------------------------------------------------------------
-// ChoiceBox — object (resolution stored as plain String, parsed to struct)
+// ChoiceBox - object (resolution stored as plain String, parsed to struct)
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
@@ -167,14 +167,14 @@ fn on_choice_obj_change(
     };
 
     let text = match cb.value.value_as_str().and_then(Resolution::from_str) {
-        Some(res) => format!("Selected: {}×{} (Resolution)", res.width, res.height),
+        Some(res) => format!("Selected: {}x{} (Resolution)", res.width, res.height),
         None => format!("Selected: {}", cb.value.text),
     };
     set_result("choice-obj-result", text, &mut paragraph_q);
 }
 
 // ---------------------------------------------------------------------------
-// RadioButton — integer (u32)  — fieldset emits HtmlChange on the FieldSet entity
+// RadioButton - integer (u32)  - fieldset emits HtmlChange on the FieldSet entity
 // ---------------------------------------------------------------------------
 
 #[html_fn("on_radio_int_change")]
@@ -200,7 +200,7 @@ fn on_radio_int_change(
 }
 
 // ---------------------------------------------------------------------------
-// RadioButton — boolean
+// RadioButton - boolean
 // ---------------------------------------------------------------------------
 
 #[html_fn("on_radio_bool_change")]
@@ -226,7 +226,7 @@ fn on_radio_bool_change(
 }
 
 // ---------------------------------------------------------------------------
-// RadioButton — enum-like (Theme, mapped from String)
+// RadioButton - enum-like (Theme, mapped from String)
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
@@ -270,7 +270,7 @@ fn on_radio_enum_change(
 }
 
 // ---------------------------------------------------------------------------
-// RadioButton — object (f32 scale factor)
+// RadioButton - object (f32 scale factor)
 // ---------------------------------------------------------------------------
 
 #[html_fn("on_radio_obj_change")]

--- a/src/html/bindings.rs
+++ b/src/html/bindings.rs
@@ -3,7 +3,7 @@ use crate::html::*;
 use crate::widgets::{
     BindToID, Button, ButtonType, CheckBox, ChoiceBox, ColorPicker, DatePicker,
     FieldSelectionMulti, FieldSelectionSingle, Form, FormValidationMode, InputField, InputValue,
-    RadioButton, Scrollbar, Slider, SwitchButton, ToggleButton, UIGenID, UIWidgetState,
+    ListBox, RadioButton, Scrollbar, Slider, SwitchButton, ToggleButton, UIGenID, UIWidgetState,
     ValidationRules, evaluate_validation_state,
 };
 use bevy::log::warn;
@@ -67,6 +67,10 @@ impl Plugin for HtmlEventBindingsPlugin {
         app.add_systems(
             Update,
             emit_choice_box_change.in_set(HtmlSystemSet::Bindings),
+        );
+        app.add_systems(
+            Update,
+            emit_list_box_change.in_set(HtmlSystemSet::Bindings),
         );
         app.add_systems(
             Update,
@@ -725,6 +729,17 @@ pub(crate) fn emit_checkbox_change(
 pub(crate) fn emit_choice_box_change(
     mut commands: Commands,
     query: Query<(Entity, &HtmlEventBindings), Changed<ChoiceBox>>,
+) {
+    for (entity, binding) in &query {
+        emit_change_if_bound(&mut commands, binding, entity, HtmlChangeAction::State);
+    }
+}
+
+/// ListBox
+/// Emits change events for list box widgets.
+pub(crate) fn emit_list_box_change(
+    mut commands: Commands,
+    query: Query<(Entity, &HtmlEventBindings), Changed<ListBox>>,
 ) {
     for (entity, binding) in &query {
         emit_change_if_bound(&mut commands, binding, entity, HtmlChangeAction::State);

--- a/src/html/builder.rs
+++ b/src/html/builder.rs
@@ -181,7 +181,8 @@ fn collect_html_ids(nodes: &Vec<HtmlWidgetNode>, ids: &mut Vec<HtmlID>) {
             | HtmlWidgetNode::Scrollbar(_, _, _, _, _, id)
             | HtmlWidgetNode::Slider(_, _, _, _, _, id)
             | HtmlWidgetNode::SwitchButton(_, _, _, _, _, id)
-            | HtmlWidgetNode::ToggleButton(_, _, _, _, _, id) => {
+            | HtmlWidgetNode::ToggleButton(_, _, _, _, _, id)
+            | HtmlWidgetNode::ListBox(_, _, _, _, _, id) => {
                 ids.push(id.clone());
             }
             HtmlWidgetNode::Div(_, _, _, children, _, _, id) => {
@@ -439,6 +440,17 @@ fn spawn_widget_node(
             spawn_with_meta(
                 commands,
                 toggle_button.clone(),
+                meta,
+                states,
+                functions,
+                widget,
+                id,
+            )
+        }
+        HtmlWidgetNode::ListBox(list_box, meta, states, functions, widget, id) => {
+            spawn_with_meta(
+                commands,
+                list_box.clone(),
                 meta,
                 states,
                 functions,

--- a/src/html/builder.rs
+++ b/src/html/builder.rs
@@ -52,22 +52,42 @@ pub fn build_html_source(
     if !html_dirty.0 {
         return;
     }
-    html_dirty.0 = false;
 
     let Some(active_list) = structure_map.active.as_ref() else {
+        html_dirty.0 = false;
+        html_dirty.1.clear();
         return;
     };
 
-    // Despawn the old active UI (recursive).
+    let rebuild_keys: Vec<String> = if html_dirty.1.is_empty() {
+        active_list.clone()
+    } else {
+        active_list
+            .iter()
+            .filter(|active| html_dirty.1.contains(*active))
+            .cloned()
+            .collect()
+    };
+
+    html_dirty.0 = false;
+    for key in &rebuild_keys {
+        html_dirty.1.remove(key);
+    }
+
+    if rebuild_keys.is_empty() {
+        return;
+    }
+
+    // Despawn only the active UI roots that actually changed.
     for (entity, body) in body_query.iter() {
         if let Some(key) = body.html_key.as_deref() {
-            if active_list.iter().any(|active| active == key) {
+            if rebuild_keys.iter().any(|dirty_key| dirty_key == key) {
                 commands.entity(entity).despawn();
             }
         }
     }
 
-    for active in active_list {
+    for active in &rebuild_keys {
         spawn_structure_for_active(
             &mut commands,
             active,

--- a/src/html/converter.rs
+++ b/src/html/converter.rs
@@ -1,10 +1,16 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use bevy::asset::AssetEvent;
+use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
+use bevy::reflect::TypeRegistry;
+use bevy::reflect::serde::TypedReflectDeserializer;
 use kuchiki::{Attributes, NodeRef, traits::TendrilSink};
 use once_cell::sync::Lazy;
 use regex::Regex;
+use serde::de::DeserializeSeed;
+use serde_json::Value as JsonValue;
 
 use crate::ExtendedUiConfiguration;
 #[cfg(feature = "extended-dialog")]
@@ -50,6 +56,14 @@ impl Plugin for HtmlConverterSystem {
 /// Marker component for HtmlSource entities that need a retry parse.
 struct PendingHtmlParse;
 
+/// Bundled query params for `update_html_ui`, keeping total system-param count ≤ 16.
+#[derive(SystemParam)]
+struct HtmlSourceQueries<'w, 's> {
+    added: Query<'w, 's, (Entity, &'static HtmlSource), Added<HtmlSource>>,
+    pending: Query<'w, 's, Entity, With<PendingHtmlParse>>,
+    all: Query<'w, 's, (Entity, &'static HtmlSource)>,
+}
+
 /// Converts HtmlAsset content into HtmlStructureMap entries.
 /// Also resolves <link rel="stylesheet" href="..."> into Handle<CssAsset>.
 /// Updates parsed HTML structures from assets and language state.
@@ -69,10 +83,11 @@ fn update_html_ui(
     #[cfg(feature = "providers")] provider_registry: Option<Res<UiProviderRegistry>>,
     #[cfg(feature = "providers")] mut theme_provider_state: Option<ResMut<ThemeProviderState>>,
 
-    query_added: Query<(Entity, &HtmlSource), Added<HtmlSource>>,
-    query_pending: Query<Entity, With<PendingHtmlParse>>,
-    query_all: Query<(Entity, &HtmlSource)>,
+    type_registry: Res<AppTypeRegistry>,
+
+    queries: HtmlSourceQueries,
 ) {
+    let type_registry = type_registry.read();
     let resolved = ui_lang.resolved().map(|lang| lang.to_string());
     let mut lang_dirty = false;
     let vars_hash = vars_fingerprint(&lang_vars);
@@ -95,8 +110,8 @@ fn update_html_ui(
     }
 
     // Entities that need reparse (new HtmlSource, pending retry, or changed HtmlAsset).
-    let mut dirty_entities: Vec<Entity> = query_added.iter().map(|(e, _)| e).collect();
-    dirty_entities.extend(query_pending.iter());
+    let mut dirty_entities: Vec<Entity> = queries.added.iter().map(|(e, _)| e).collect();
+    dirty_entities.extend(queries.pending.iter());
 
     // If an HtmlAsset changed OR was added later (async), find all entities referencing it.
     for ev in html_asset_events.read() {
@@ -107,7 +122,7 @@ fn update_html_ui(
             _ => continue,
         };
 
-        for (entity, src) in query_all.iter() {
+        for (entity, src) in queries.all.iter() {
             if src.handle.id() == id {
                 dirty_entities.push(entity);
             }
@@ -118,7 +133,7 @@ fn update_html_ui(
     dirty_entities.dedup();
 
     if lang_dirty {
-        dirty_entities.extend(query_all.iter().map(|(e, _)| e));
+        dirty_entities.extend(queries.all.iter().map(|(e, _)| e));
         dirty_entities.sort();
         dirty_entities.dedup();
     }
@@ -128,7 +143,7 @@ fn update_html_ui(
     }
 
     for entity in dirty_entities {
-        let Ok((_entity, html)) = query_all.get(entity) else {
+        let Ok((_entity, html)) = queries.all.get(entity) else {
             continue;
         };
 
@@ -257,7 +272,7 @@ fn update_html_ui(
         let label_map = collect_labels_by_for(&body_node);
 
         if let Some(body_widget) =
-            parse_html_node(&body_node, &css_handles, &label_map, &ui_key, html)
+            parse_html_node(&body_node, &css_handles, &label_map, &ui_key, html, &type_registry)
         {
             structure_map.html_map.insert(ui_key, vec![body_widget]);
 
@@ -276,6 +291,7 @@ fn parse_html_node(
     label_map: &HashMap<String, String>,
     key: &String,
     html: &HtmlSource,
+    type_registry: &TypeRegistry,
 ) -> Option<HtmlWidgetNode> {
     let element = node.as_element()?;
     let tag = element.name.local.to_string();
@@ -306,7 +322,7 @@ fn parse_html_node(
         "body" => {
             let children = node
                 .children()
-                .filter_map(|child| parse_html_node(&child, css_sources, label_map, key, html))
+                .filter_map(|child| parse_html_node(&child, css_sources, label_map, key, html, type_registry))
                 .collect();
 
             Some(HtmlWidgetNode::Body(
@@ -404,7 +420,7 @@ fn parse_html_node(
         "div" => {
             let mut children = Vec::new();
             for child in node.children() {
-                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html) {
+                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html, type_registry) {
                     children.push(parsed);
                 }
             }
@@ -423,7 +439,7 @@ fn parse_html_node(
         "form" => {
             let mut children = Vec::new();
             for child in node.children() {
-                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html) {
+                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html, type_registry) {
                     children.push(parsed);
                 }
             }
@@ -458,7 +474,7 @@ fn parse_html_node(
         "dialog" => {
             let mut children = Vec::new();
             for child in node.children() {
-                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html) {
+                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html, type_registry) {
                     children.push(parsed);
                 }
             }
@@ -503,7 +519,7 @@ fn parse_html_node(
         "dialog-header" => {
             let mut children = Vec::new();
             for child in node.children() {
-                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html) {
+                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html, type_registry) {
                     children.push(parsed);
                 }
             }
@@ -526,7 +542,7 @@ fn parse_html_node(
         "dialog-body" => {
             let mut children = Vec::new();
             for child in node.children() {
-                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html) {
+                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html, type_registry) {
                     children.push(parsed);
                 }
             }
@@ -549,7 +565,7 @@ fn parse_html_node(
         "dialog-footer" => {
             let mut children = Vec::new();
             for child in node.children() {
-                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html) {
+                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html, type_registry) {
                     children.push(parsed);
                 }
             }
@@ -598,7 +614,7 @@ fn parse_html_node(
                         continue;
                     }
                 }
-                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html) {
+                if let Some(parsed) = parse_html_node(&child, css_sources, label_map, key, html, type_registry) {
                     children.push(parsed);
                 }
             }
@@ -611,7 +627,9 @@ fn parse_html_node(
                 let element = radio_node.as_element().unwrap();
                 let attrs = element.attributes.borrow();
 
-                let value = attrs.get("value").unwrap_or("").to_string();
+                let value_str = attrs.get("value").unwrap_or("").to_string();
+                let value_type = attrs.get("internal-value-type").unwrap_or("").trim().to_ascii_lowercase();
+                let value = parse_option_internal_value(&value_str, &value_type, type_registry);
                 let label = radio_node.text_contents().trim().to_string();
 
                 let selected = if any_selected_attr {
@@ -656,6 +674,7 @@ fn parse_html_node(
                         selected,
                         ..default()
                     },
+
                     child_meta,
                     child_states,
                     child_functions,
@@ -1011,7 +1030,9 @@ fn parse_html_node(
         }
 
         "radio" => {
-            let value = attributes.get("value").unwrap_or("").to_string();
+            let value_str = attributes.get("value").unwrap_or("").to_string();
+            let value_type = attributes.get("internal-value-type").unwrap_or("").trim().to_ascii_lowercase();
+            let value = parse_option_internal_value(&value_str, &value_type, type_registry);
             let label = node.text_contents().trim().to_string();
             let selected_attr = attributes.contains("selected");
 
@@ -1058,6 +1079,7 @@ fn parse_html_node(
                     if option_el.name.local.eq("option") {
                         let attrs = option_el.attributes.borrow();
                         let value = attrs.get("value").unwrap_or("").to_string();
+                        let value_type = attrs.get("internal-value-type").unwrap_or("").trim().to_ascii_lowercase();
                         let icon = attrs.get("icon").unwrap_or("").to_string();
                         let text = child.text_contents().trim().to_string();
 
@@ -1067,9 +1089,11 @@ fn parse_html_node(
                             Some(icon)
                         };
 
+                        let internal_value = parse_option_internal_value(&value, &value_type, type_registry);
+
                         let option = ChoiceOption {
                             text: text.clone(),
-                            internal_value: value.clone(),
+                            internal_value,
                             icon_path,
                         };
 
@@ -1875,4 +1899,71 @@ mod tests {
         assert!(content.inner_html().contains("<b>{{ user.name }}</b>"));
         assert_eq!(content.inner_bindings(), &["{{ user.name }}".to_string()]);
     }
+}
+
+/// Converts an HTML option's `value` string into an `Arc<dyn Any + Send + Sync>` using the
+/// `internal-value-type` attribute hint.
+///
+/// # Primitive types (parsed directly from the string)
+/// `bool`, `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `f32`, `f64`, `string` / `str`
+///
+/// # Structured types (deserialized via Bevy reflection)
+/// Any other type name — looked up in the Bevy `TypeRegistry` by short path (e.g. `"MyStruct"`)
+/// then deserialized from the JSON value string using `TypedReflectDeserializer` and wrapped in
+/// a [`ReflectedValue`]. Falls back to `serde_json::Value` if the type is not registered, and
+/// to a plain `String` if that also fails.
+///
+/// # Fallback
+/// An empty or unrecognised `type_hint` stores the value as a plain `String`.
+fn parse_option_internal_value(
+    value: &str,
+    type_hint: &str,
+    type_registry: &TypeRegistry,
+) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+    use crate::widgets::ReflectedValue;
+
+    if value.is_empty() {
+        return None;
+    }
+
+    let arc: Arc<dyn std::any::Any + Send + Sync> = match type_hint {
+        "bool" => match value.trim() {
+            "true" | "1" | "yes" => Arc::new(true),
+            _ => Arc::new(false),
+        },
+        "i8"  => Arc::new(value.trim().parse::<i8>().unwrap_or(0)),
+        "i16" => Arc::new(value.trim().parse::<i16>().unwrap_or(0)),
+        "i32" => Arc::new(value.trim().parse::<i32>().unwrap_or(0)),
+        "i64" => Arc::new(value.trim().parse::<i64>().unwrap_or(0)),
+        "u8"  => Arc::new(value.trim().parse::<u8>().unwrap_or(0)),
+        "u16" => Arc::new(value.trim().parse::<u16>().unwrap_or(0)),
+        "u32" => Arc::new(value.trim().parse::<u32>().unwrap_or(0)),
+        "u64" => Arc::new(value.trim().parse::<u64>().unwrap_or(0)),
+        "f32" => Arc::new(value.trim().parse::<f32>().unwrap_or(0.0)),
+        "f64" => Arc::new(value.trim().parse::<f64>().unwrap_or(0.0)),
+        "" | "string" | "str" => Arc::new(value.to_string()),
+        type_name => {
+            // Try Bevy reflection first (short path, then full path).
+            let registration = type_registry
+                .get_with_short_type_path(type_name)
+                .or_else(|| type_registry.get_with_type_path(type_name));
+
+            if let Some(registration) = registration {
+                let deserializer = TypedReflectDeserializer::new(registration, type_registry);
+                let mut json_de = serde_json::Deserializer::from_str(value);
+                match deserializer.deserialize(&mut json_de) {
+                    Ok(reflected) => Arc::new(ReflectedValue(reflected)),
+                    Err(_) => Arc::new(value.to_string()),
+                }
+            } else {
+                // Type not registered — fall back to serde_json::Value, then String.
+                match serde_json::from_str::<JsonValue>(value) {
+                    Ok(json) => Arc::new(json),
+                    Err(_) => Arc::new(value.to_string()),
+                }
+            }
+        }
+    };
+
+    Some(arc)
 }

--- a/src/html/converter.rs
+++ b/src/html/converter.rs
@@ -272,10 +272,11 @@ fn update_html_ui(
         if let Some(body_widget) =
             parse_html_node(&body_node, &css_handles, &label_map, &ui_key, html, &type_registry)
         {
-            structure_map.html_map.insert(ui_key, vec![body_widget]);
+            structure_map.html_map.insert(ui_key.clone(), vec![body_widget]);
 
-            // IMPORTANT: Explicitly mark UI as dirty so the builder rebuilds.
+            // IMPORTANT: Explicitly mark the affected UI key as dirty so the builder rebuilds.
             html_dirty.0 = true;
+            html_dirty.1.insert(ui_key);
         } else {
             error!("Failed to parse <body> node.");
         }
@@ -1532,6 +1533,10 @@ pub fn resolve_relative_asset_path(html_path: &str, href: &str) -> String {
 
     if let Some(rest) = href.strip_prefix('/') {
         return rest.to_string();
+    }
+
+    if href.starts_with("./") || href.starts_with("../") {
+        return href;
     }
 
     let base = std::path::Path::new(html_path)

--- a/src/html/converter.rs
+++ b/src/html/converter.rs
@@ -1,6 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-
 use bevy::asset::AssetEvent;
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
@@ -1089,11 +1087,11 @@ fn parse_html_node(
                             Some(icon)
                         };
 
-                        let internal_value = parse_option_internal_value(&value, &value_type, type_registry);
+                        let value = parse_option_internal_value(&value, &value_type, type_registry);
 
                         let option = ChoiceOption {
                             text: text.clone(),
-                            internal_value,
+                            value,
                             icon_path,
                         };
 
@@ -1227,7 +1225,7 @@ fn parse_html_node(
                 ToggleButton {
                     label: text.clone(),
                     icon_path,
-                    value,
+                    value: WidgetValue::new(value),
                     icon_place,
                     selected: selected_attr,
                     ..default()
@@ -1264,12 +1262,11 @@ fn parse_html_node(
                             Some(icon)
                         };
 
-                        let internal_value =
-                            parse_option_internal_value(&value, &value_type, type_registry);
+                        let value = parse_option_internal_value(&value, &value_type, type_registry);
 
                         let option = ChoiceOption {
                             text: text.clone(),
-                            internal_value,
+                            value,
                             icon_path,
                         };
 
@@ -1958,7 +1955,7 @@ mod tests {
     }
 }
 
-/// Converts an HTML option's `value` string into an `Arc<dyn Any + Send + Sync>` using the
+/// Converts an HTML option's `value` string into a [`WidgetValue`] using the
 /// `internal-value-type` attribute hint.
 ///
 /// # Primitive types (parsed directly from the string)
@@ -1976,29 +1973,29 @@ fn parse_option_internal_value(
     value: &str,
     type_hint: &str,
     type_registry: &TypeRegistry,
-) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
+) -> WidgetValue {
     use crate::widgets::ReflectedValue;
 
     if value.is_empty() {
-        return None;
+        return WidgetValue::default();
     }
 
-    let arc: Arc<dyn std::any::Any + Send + Sync> = match type_hint {
+    match type_hint {
         "bool" => match value.trim() {
-            "true" | "1" | "yes" => Arc::new(true),
-            _ => Arc::new(false),
+            "true" | "1" | "yes" => WidgetValue::new(true),
+            _ => WidgetValue::new(false),
         },
-        "i8"  => Arc::new(value.trim().parse::<i8>().unwrap_or(0)),
-        "i16" => Arc::new(value.trim().parse::<i16>().unwrap_or(0)),
-        "i32" => Arc::new(value.trim().parse::<i32>().unwrap_or(0)),
-        "i64" => Arc::new(value.trim().parse::<i64>().unwrap_or(0)),
-        "u8"  => Arc::new(value.trim().parse::<u8>().unwrap_or(0)),
-        "u16" => Arc::new(value.trim().parse::<u16>().unwrap_or(0)),
-        "u32" => Arc::new(value.trim().parse::<u32>().unwrap_or(0)),
-        "u64" => Arc::new(value.trim().parse::<u64>().unwrap_or(0)),
-        "f32" => Arc::new(value.trim().parse::<f32>().unwrap_or(0.0)),
-        "f64" => Arc::new(value.trim().parse::<f64>().unwrap_or(0.0)),
-        "" | "string" | "str" => Arc::new(value.to_string()),
+        "i8" => WidgetValue::new(value.trim().parse::<i8>().unwrap_or(0)),
+        "i16" => WidgetValue::new(value.trim().parse::<i16>().unwrap_or(0)),
+        "i32" => WidgetValue::new(value.trim().parse::<i32>().unwrap_or(0)),
+        "i64" => WidgetValue::new(value.trim().parse::<i64>().unwrap_or(0)),
+        "u8" => WidgetValue::new(value.trim().parse::<u8>().unwrap_or(0)),
+        "u16" => WidgetValue::new(value.trim().parse::<u16>().unwrap_or(0)),
+        "u32" => WidgetValue::new(value.trim().parse::<u32>().unwrap_or(0)),
+        "u64" => WidgetValue::new(value.trim().parse::<u64>().unwrap_or(0)),
+        "f32" => WidgetValue::new(value.trim().parse::<f32>().unwrap_or(0.0)),
+        "f64" => WidgetValue::new(value.trim().parse::<f64>().unwrap_or(0.0)),
+        "" | "string" | "str" => WidgetValue::new(value.to_string()),
         type_name => {
             // Try Bevy reflection first (short path, then full path).
             let registration = type_registry
@@ -2009,18 +2006,16 @@ fn parse_option_internal_value(
                 let deserializer = TypedReflectDeserializer::new(registration, type_registry);
                 let mut json_de = serde_json::Deserializer::from_str(value);
                 match deserializer.deserialize(&mut json_de) {
-                    Ok(reflected) => Arc::new(ReflectedValue(reflected)),
-                    Err(_) => Arc::new(value.to_string()),
+                    Ok(reflected) => WidgetValue::new(ReflectedValue(reflected)),
+                    Err(_) => WidgetValue::new(value.to_string()),
                 }
             } else {
                 // Type not registered — fall back to serde_json::Value, then String.
                 match serde_json::from_str::<JsonValue>(value) {
-                    Ok(json) => Arc::new(json),
-                    Err(_) => Arc::new(value.to_string()),
+                    Ok(json) => WidgetValue::new(json),
+                    Err(_) => WidgetValue::new(value.to_string()),
                 }
             }
         }
-    };
-
-    Some(arc)
+    }
 }

--- a/src/html/converter.rs
+++ b/src/html/converter.rs
@@ -1240,6 +1240,63 @@ fn parse_html_node(
             ))
         }
 
+        "listbox" => {
+            let mut options = Vec::new();
+            let mut selected_values = Vec::new();
+            let multiselect = attributes.contains("multiselect");
+
+            for child in node.children() {
+                if let Some(option_el) = child.as_element() {
+                    if option_el.name.local.eq("option") {
+                        let attrs = option_el.attributes.borrow();
+                        let value = attrs.get("value").unwrap_or("").to_string();
+                        let value_type = attrs
+                            .get("internal-value-type")
+                            .unwrap_or("")
+                            .trim()
+                            .to_ascii_lowercase();
+                        let icon = attrs.get("icon").unwrap_or("").to_string();
+                        let text = child.text_contents().trim().to_string();
+
+                        let icon_path = if icon.trim().is_empty() {
+                            None
+                        } else {
+                            Some(icon)
+                        };
+
+                        let internal_value =
+                            parse_option_internal_value(&value, &value_type, type_registry);
+
+                        let option = ChoiceOption {
+                            text: text.clone(),
+                            internal_value,
+                            icon_path,
+                        };
+
+                        if attrs.contains("selected") {
+                            selected_values.push(option.clone());
+                        }
+
+                        options.push(option);
+                    }
+                }
+            }
+
+            Some(HtmlWidgetNode::ListBox(
+                ListBox {
+                    options,
+                    values: selected_values,
+                    multiselect,
+                    ..default()
+                },
+                meta,
+                states,
+                functions,
+                widget.clone(),
+                HtmlID::default(),
+            ))
+        }
+
         _ => None,
     }
 }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -23,8 +23,8 @@ use crate::styles::Style;
 use crate::styles::parser::apply_property_to_style;
 use crate::widgets::{
     Badge, Body, Button, CheckBox, ChoiceBox, ColorPicker, DatePicker, Div, Divider, FieldSet,
-    Form, Headline, HyperLink, Img, InputField, Paragraph, ProgressBar, RadioButton, Scrollbar,
-    Slider, SwitchButton, ToggleButton, ToolTip, ValidationRules, Widget,
+    Form, Headline, HyperLink, Img, InputField, ListBox, Paragraph, ProgressBar, RadioButton,
+    Scrollbar, Slider, SwitchButton, ToggleButton, ToolTip, ValidationRules, Widget,
 };
 
 pub static HTML_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
@@ -429,6 +429,15 @@ pub enum HtmlWidgetNode {
     /// A toggle-button `<toggle>`.
     ToggleButton(
         ToggleButton,
+        HtmlMeta,
+        HtmlStates,
+        HtmlEventBindings,
+        Widget,
+        HtmlID,
+    ),
+    /// A list box `<listbox>`.
+    ListBox(
+        ListBox,
         HtmlMeta,
         HtmlStates,
         HtmlEventBindings,

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -13,7 +13,7 @@ use crate::html::reload::HtmlReloadPlugin;
 use crate::lang::{UILang, UiLangState, UiLangVariables};
 use bevy::ecs::system::SystemId;
 use bevy::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(feature = "extended-dialog")]
@@ -100,11 +100,12 @@ pub struct ShowWidgetsTimer {
 #[derive(Event, Message)]
 pub struct HtmlChangeEvent;
 
-/// A simple explicit "UI needs rebuild" flag.
-/// We use this because mutating the internal HashMap of HtmlStructureMap
+/// Tracks whether the HTML UI needs rebuilding and, when possible, which UI keys changed.
+///
+/// We use this because mutating the internal HashMap of `HtmlStructureMap`
 /// does NOT reliably trigger `resource_changed::<HtmlStructureMap>()`.
 #[derive(Resource, Default)]
-pub struct HtmlDirty(pub bool);
+pub struct HtmlDirty(pub bool, pub HashSet<String>);
 
 /// Component storing parsed inline CSS (`style="..."`) as your custom Style struct.
 /// Component storing parsed inline CSS (`style="..."`) as a `Style`.

--- a/src/html/unit_tests.rs
+++ b/src/html/unit_tests.rs
@@ -994,6 +994,93 @@ mod tests {
     }
 
     #[test]
+    fn builder_rebuilds_only_dirty_active_keys() {
+        let mut app = setup_converter_app();
+        app.add_message::<HtmlAllWidgetsSpawned>();
+        app.add_systems(Update, builder::build_html_source);
+
+        add_html_source(
+            &mut app,
+            "examples/build_fixture_a.html",
+            html_fixture(),
+            "build-key-a",
+            Some("builder::controller"),
+        );
+        add_html_source(
+            &mut app,
+            "examples/build_fixture_b.html",
+            html_fixture(),
+            "build-key-b",
+            Some("builder::controller"),
+        );
+
+        app.update();
+
+        {
+            let mut dirty = app.world_mut().resource_mut::<HtmlDirty>();
+            dirty.0 = false;
+            dirty.1.clear();
+        }
+
+        let old_body_a = app
+            .world_mut()
+            .spawn(Body {
+                entry: 111_111,
+                html_key: Some("build-key-a".to_string()),
+            })
+            .id();
+        let old_body_b = app
+            .world_mut()
+            .spawn(Body {
+                entry: 222_222,
+                html_key: Some("build-key-b".to_string()),
+            })
+            .id();
+
+        {
+            let mut map = app.world_mut().resource_mut::<HtmlStructureMap>();
+            map.active = Some(vec!["build-key-a".to_string(), "build-key-b".to_string()]);
+        }
+        {
+            let mut dirty = app.world_mut().resource_mut::<HtmlDirty>();
+            dirty.0 = true;
+            dirty.1.insert("build-key-a".to_string());
+        }
+
+        app.update();
+
+        let mut body_query = app.world_mut().query::<(Entity, &Body)>();
+        let all_bodies: Vec<(Entity, String)> = body_query
+            .iter(app.world())
+            .map(|(entity, body)| (entity, body.html_key.clone().unwrap_or_default()))
+            .collect();
+
+        assert_eq!(
+            all_bodies
+                .iter()
+                .filter(|(_, key)| key == "build-key-a")
+                .count(),
+            1
+        );
+        assert_eq!(
+            all_bodies
+                .iter()
+                .filter(|(_, key)| key == "build-key-b")
+                .count(),
+            1
+        );
+
+        assert!(
+            !app.world().entities().contains(old_body_a),
+            "dirty active body should be replaced"
+        );
+        assert!(
+            app.world().entities().contains(old_body_b),
+            "clean active body should be left untouched"
+        );
+    }
+
+    #[test]
     fn builder_noops_when_not_dirty_and_clears_dirty_without_active() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, AssetPlugin::default()));

--- a/src/html/unit_tests.rs
+++ b/src/html/unit_tests.rs
@@ -766,12 +766,12 @@ mod tests {
         assert!(all.iter().any(|node| matches!(
             node,
             HtmlWidgetNode::ToggleButton(ToggleButton { value, icon_place: IconPlace::Right, selected: true, .. }, _, _, _, _, _)
-                if value == "t1"
+                if value.as_str() == Some("t1")
         )));
         assert!(all.iter().any(|node| matches!(
             node,
             HtmlWidgetNode::ToggleButton(ToggleButton { value, icon_place: IconPlace::Left, selected: false, .. }, _, _, _, _, _)
-                if value == "t2"
+                if value.as_str() == Some("t2")
         )));
 
         assert!(all.iter().any(|node| matches!(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -29,6 +29,7 @@ pub static SLIDER_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool:
 pub static COLOR_PICKER_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 pub static SWITCH_BUTTON_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 pub static TOGGLE_BUTTON_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
+pub static LIST_BOX_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 
 /// A pool that manages reusable integer IDs for widgets.
 /// It hands out new IDs or recycles freed IDs.
@@ -454,6 +455,7 @@ fn despawn_widget_ids(
                 WidgetKind::Scrollbar => SCROLL_ID_POOL.lock().unwrap().release(widget_id.id),
                 WidgetKind::Divider => DIVIDER_ID_POOL.lock().unwrap().release(widget_id.id),
                 WidgetKind::FieldSet => FIELDSET_ID_POOL.lock().unwrap().release(widget_id.id),
+                WidgetKind::ListBox => LIST_BOX_ID_POOL.lock().unwrap().release(widget_id.id),
             }
         }
     }

--- a/src/services/css_service.rs
+++ b/src/services/css_service.rs
@@ -33,6 +33,7 @@ struct ParsedCssWithVarsKey {
 #[derive(Resource, Default)]
 pub struct CssUsers {
     pub users: HashMap<AssetId<CssAsset>, HashSet<Entity>>,
+    entity_assets: HashMap<Entity, Vec<AssetId<CssAsset>>>,
 }
 
 /// Stores the last known primary-window size to detect breakpoint changes.
@@ -105,9 +106,10 @@ fn invalidate_css_cache_on_asset_change(mut ev: MessageReader<AssetEvent<CssAsse
     }
 }
 
-fn get_or_parse_css(handle: &Handle<CssAsset>, css_assets: &Assets<CssAsset>) -> Option<ParsedCss> {
-    let asset_id = handle.id();
-
+fn get_or_parse_css_by_id(
+    asset_id: AssetId<CssAsset>,
+    css_assets: &Assets<CssAsset>,
+) -> Option<ParsedCss> {
     if let Some(cached) = PARSED_CSS_CACHE
         .read()
         .ok()
@@ -116,12 +118,16 @@ fn get_or_parse_css(handle: &Handle<CssAsset>, css_assets: &Assets<CssAsset>) ->
         return Some(cached);
     }
 
-    let css_asset = css_assets.get(handle)?;
+    let css_asset = css_assets.get(asset_id)?;
     let parsed = load_css(&css_asset.text);
     if let Ok(mut cache) = PARSED_CSS_CACHE.write() {
         cache.insert(asset_id, parsed.clone());
     }
     Some(parsed)
+}
+
+fn get_or_parse_css(handle: &Handle<CssAsset>, css_assets: &Assets<CssAsset>) -> Option<ParsedCss> {
+    get_or_parse_css_by_id(handle.id(), css_assets)
 }
 
 fn hash_root_vars(root_vars: &HashMap<String, String>) -> u64 {
@@ -211,31 +217,61 @@ fn collect_global_root_vars_for_sources(
     vars
 }
 
-/// Updates the reverse index of entities using each CSS asset.
-fn update_css_users_index(
-    mut css_users: ResMut<CssUsers>,
-    query_changed: Query<(Entity, &CssSource), Or<(Added<CssSource>, Changed<CssSource>)>>,
-) {
-    for (entity, css_source) in query_changed.iter() {
-        // Remove entity from all previous sets
-        for set in css_users.users.values_mut() {
-            set.remove(&entity);
-        }
+fn remove_entity_from_css_users(css_users: &mut CssUsers, entity: Entity) {
+    let Some(previous_assets) = css_users.entity_assets.remove(&entity) else {
+        return;
+    };
 
-        // Add entity to new CSS handles
-        for h in &css_source.0 {
-            css_users.users.entry(h.id()).or_default().insert(entity);
+    for asset_id in previous_assets {
+        let should_remove = if let Some(set) = css_users.users.get_mut(&asset_id) {
+            set.remove(&entity);
+            set.is_empty()
+        } else {
+            false
+        };
+
+        if should_remove {
+            css_users.users.remove(&asset_id);
         }
     }
 }
 
-/// Marks all CSS users dirty when the active breakpoint viewport changes.
+/// Updates the reverse index of entities using each CSS asset.
+fn update_css_users_index(
+    mut css_users: ResMut<CssUsers>,
+    query_changed: Query<(Entity, &CssSource), Or<(Added<CssSource>, Changed<CssSource>)>>,
+    mut removed_sources: RemovedComponents<CssSource>,
+) {
+    for entity in removed_sources.read() {
+        remove_entity_from_css_users(&mut css_users, entity);
+    }
+
+    for (entity, css_source) in query_changed.iter() {
+        remove_entity_from_css_users(&mut css_users, entity);
+
+        let mut current_assets = Vec::with_capacity(css_source.0.len());
+
+        for handle in &css_source.0 {
+            let asset_id = handle.id();
+            css_users.users.entry(asset_id).or_default().insert(entity);
+            if !current_assets.contains(&asset_id) {
+                current_assets.push(asset_id);
+            }
+        }
+
+        if !current_assets.is_empty() {
+            css_users.entity_assets.insert(entity, current_assets);
+        }
+    }
+}
+
+/// Marks only affected CSS users dirty when breakpoint/media-query matches change.
 fn mark_css_users_dirty_on_viewport_change(
     mut commands: Commands,
     mut viewport_tracker: ResMut<CssViewportTracker>,
     window_query: Query<&Window, With<PrimaryWindow>>,
     css_assets: Res<Assets<CssAsset>>,
-    css_query: Query<(Entity, &CssSource)>,
+    css_users: Res<CssUsers>,
 ) {
     let Some(next_viewport) = resolve_breakpoint_viewport(&window_query) else {
         return;
@@ -250,21 +286,33 @@ fn mark_css_users_dirty_on_viewport_change(
 
     let prev_viewport = Vec2::new(viewport_tracker.width, viewport_tracker.height);
 
-    let breakpoint_changed = if prev_viewport.x < 0.0 || prev_viewport.y < 0.0 {
+    let affected_assets = if prev_viewport.x < 0.0 || prev_viewport.y < 0.0 {
         // Initial resize tracking warm-up: startup CssSource insertion already triggers CSS apply.
-        false
+        HashSet::new()
     } else {
-        media_match_changed_between_viewports(&css_query, &css_assets, prev_viewport, next_viewport)
+        collect_assets_with_changed_media_matches(
+            &css_users,
+            &css_assets,
+            prev_viewport,
+            next_viewport,
+        )
     };
 
     viewport_tracker.width = next_viewport.x;
     viewport_tracker.height = next_viewport.y;
 
-    if !breakpoint_changed {
+    if affected_assets.is_empty() {
         return;
     }
 
-    for (entity, _) in css_query.iter() {
+    let mut affected_entities = HashSet::new();
+    for asset_id in affected_assets {
+        if let Some(users) = css_users.users.get(&asset_id) {
+            affected_entities.extend(users.iter().copied());
+        }
+    }
+
+    for entity in affected_entities {
         if let Ok(mut entity_commands) = commands.get_entity(entity) {
             entity_commands.insert(CssDirty);
         }
@@ -312,41 +360,34 @@ fn resolve_breakpoint_viewport(
     None
 }
 
-/// Returns true when at least one media rule changes the match state between two viewports.
-fn media_match_changed_between_viewports(
-    css_query: &Query<(Entity, &CssSource)>,
+/// Returns the CSS asset ids whose media rules change match state between two viewports.
+pub(crate) fn collect_assets_with_changed_media_matches(
+    css_users: &CssUsers,
     css_assets: &Assets<CssAsset>,
     prev_viewport: Vec2,
     next_viewport: Vec2,
-) -> bool {
-    let mut seen_assets = HashSet::new();
+) -> HashSet<AssetId<CssAsset>> {
+    let mut affected_assets = HashSet::new();
 
-    for (_, css_source) in css_query.iter() {
-        for handle in &css_source.0 {
-            let asset_id = handle.id();
-            if !seen_assets.insert(asset_id) {
-                continue;
-            }
+    for asset_id in css_users.users.keys().copied() {
+        let Some(parsed) = get_or_parse_css_by_id(asset_id, css_assets) else {
+            continue;
+        };
 
-            let Some(parsed) = get_or_parse_css(handle, css_assets) else {
-                continue;
+        let media_changed = parsed.styles.values().any(|style| {
+            let Some(media) = style.media.as_ref() else {
+                return false;
             };
 
-            for style in parsed.styles.values() {
-                let Some(media) = style.media.as_ref() else {
-                    continue;
-                };
+            media.matches_viewport(prev_viewport) != media.matches_viewport(next_viewport)
+        });
 
-                let old_match = media.matches_viewport(prev_viewport);
-                let new_match = media.matches_viewport(next_viewport);
-                if old_match != new_match {
-                    return true;
-                }
-            }
+        if media_changed {
+            affected_assets.insert(asset_id);
         }
     }
 
-    false
+    affected_assets
 }
 
 /// Applies merged CSS styles to entities that are dirty or affected by changes.

--- a/src/services/state_service.rs
+++ b/src/services/state_service.rs
@@ -1,6 +1,13 @@
 use crate::CurrentWidgetState;
 use crate::widgets::{BindToID, IgnoreParentState, UIGenID, UIWidgetState};
 use bevy::prelude::*;
+use std::collections::HashMap;
+
+#[derive(Resource, Default)]
+pub(crate) struct BoundStateIndex {
+    by_widget: HashMap<usize, Vec<Entity>>,
+    by_entity: HashMap<Entity, usize>,
+}
 
 /// Plugin that manages widget focus and state propagation.
 pub struct StateService;
@@ -8,8 +15,9 @@ pub struct StateService;
 impl Plugin for StateService {
     /// Registers widget state systems.
     fn build(&self, app: &mut App) {
+        app.init_resource::<BoundStateIndex>();
         app.register_type::<Pickable>();
-        app.add_systems(PostUpdate, update_widget_states);
+        app.add_systems(PostUpdate, (refresh_bound_state_index, update_widget_states).chain());
         app.add_systems(
             Update,
             (
@@ -18,6 +26,46 @@ impl Plugin for StateService {
                 unfocus_disabled,
             ),
         );
+    }
+}
+
+fn remove_from_bound_state_index(index: &mut BoundStateIndex, entity: Entity, widget_id: usize) {
+    let should_remove = if let Some(entries) = index.by_widget.get_mut(&widget_id) {
+        entries.retain(|current| *current != entity);
+        entries.is_empty()
+    } else {
+        false
+    };
+
+    if should_remove {
+        index.by_widget.remove(&widget_id);
+    }
+}
+
+fn refresh_bound_state_index(
+    mut index: ResMut<BoundStateIndex>,
+    query: Query<(Entity, &BindToID), Or<(Added<BindToID>, Changed<BindToID>)>>,
+    mut removed: RemovedComponents<BindToID>,
+) {
+    for entity in removed.read() {
+        if let Some(previous_id) = index.by_entity.remove(&entity) {
+            remove_from_bound_state_index(&mut index, entity, previous_id);
+        }
+    }
+
+    for (entity, bind_to) in query.iter() {
+        let widget_id = bind_to.0;
+
+        if let Some(previous_id) = index.by_entity.insert(entity, widget_id) {
+            if previous_id != widget_id {
+                remove_from_bound_state_index(&mut index, entity, previous_id);
+            }
+        }
+
+        let entries = index.by_widget.entry(widget_id).or_default();
+        if !entries.contains(&entity) {
+            entries.push(entity);
+        }
     }
 }
 
@@ -39,13 +87,31 @@ impl Plugin for StateService {
 /// will also be marked as focused.
 pub fn update_widget_states(
     main_query: Query<(&UIGenID, &UIWidgetState), (Changed<UIWidgetState>, With<UIGenID>)>,
+    index: Option<Res<BoundStateIndex>>,
     mut inner_query: Query<
-        (&BindToID, &mut UIWidgetState),
+        (Entity, &BindToID, &mut UIWidgetState),
         (Without<UIGenID>, Without<IgnoreParentState>),
     >,
 ) {
     for (id, state) in main_query.iter() {
-        for (bind_to, mut inner_state) in inner_query.iter_mut() {
+        if let Some(index) = index.as_ref() {
+            if let Some(targets) = index.by_widget.get(&id.get()) {
+                for entity in targets {
+                    let Ok((_, _, mut inner_state)) = inner_query.get_mut(*entity) else {
+                        continue;
+                    };
+
+                    inner_state.hovered = state.hovered;
+                    inner_state.focused = state.focused;
+                    inner_state.readonly = state.readonly;
+                    inner_state.disabled = state.disabled;
+                    inner_state.checked = state.checked;
+                }
+                continue;
+            }
+        }
+
+        for (_, bind_to, mut inner_state) in inner_query.iter_mut() {
             if bind_to.0 != id.get() {
                 continue;
             }

--- a/src/services/style_service.rs
+++ b/src/services/style_service.rs
@@ -11,7 +11,7 @@ use crate::styles::{
     Style, TextTransform, TransformStyle, TransitionProperty, TransitionSpec,
 };
 use crate::widgets::UIWidgetState;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bevy::asset::RenderAssetUsages;
 use bevy::asset::{load_internal_asset, uuid_handle};
@@ -47,10 +47,30 @@ use bevy::ui_render::{DrawUiMaterial, TransparentUi, UiCameraView};
 use bevy::window::{
     CursorIcon, CustomCursor, CustomCursorImage, PrimaryWindow, SystemCursorIcon, WindowResized,
 };
+use once_cell::sync::Lazy;
+use std::sync::RwLock;
 
 const BACKDROP_BLUR_SHADER_HANDLE: Handle<Shader> =
     uuid_handle!("9d04a8bb-b6cf-4758-bca8-30706480973f");
 const MAX_BACKDROP_BLUR_PX: f32 = 80.0;
+
+const SELECTOR_READ_ONLY: u8 = 1 << 0;
+const SELECTOR_DISABLED: u8 = 1 << 1;
+const SELECTOR_CHECKED: u8 = 1 << 2;
+const SELECTOR_FOCUS: u8 = 1 << 3;
+const SELECTOR_HOVER: u8 = 1 << 4;
+const SELECTOR_INVALID: u8 = 1 << 5;
+
+static SELECTOR_METADATA_CACHE: Lazy<RwLock<HashMap<String, SelectorMetadata>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SelectorMetadata {
+    specificity: u32,
+    pseudo_flags: u8,
+    has_pseudo: bool,
+    skip: bool,
+}
 
 /// Plugin that applies CSS styles, transitions, and animations to UI nodes.
 pub struct StyleService;
@@ -379,15 +399,15 @@ pub fn update_widget_styles_system(
                 style_pair.selector.as_str()
             };
 
-            if selector.contains("::") {
+            let metadata = selector_metadata(selector);
+            if metadata.skip {
                 continue;
             }
-            if selector_matches_state(selector, &state) {
-                let specificity = selector_specificity(selector);
-                if selector.contains(':') {
-                    pseudo_styles.push((key, specificity, style_pair.origin));
+            if selector_matches_state(metadata, &state) {
+                if metadata.has_pseudo {
+                    pseudo_styles.push((key, metadata.specificity, style_pair.origin));
                 } else {
-                    base_styles.push((key, specificity, style_pair.origin));
+                    base_styles.push((key, metadata.specificity, style_pair.origin));
                 }
             }
         }
@@ -2581,51 +2601,99 @@ fn lerp(from: f32, to: f32, t: f32) -> f32 {
     from + (to - from) * t
 }
 
-/// Returns true if the selector's pseudo state matches the widget state.
-fn selector_matches_state(selector: &str, state: &UIWidgetState) -> bool {
-    for part in selector.replace('>', " > ").split_whitespace() {
-        if part == ">" {
-            continue;
-        }
-        let segments: Vec<&str> = part.split(':').collect();
-        for pseudo in &segments[1..] {
-            match *pseudo {
-                "read-only" if !state.readonly => return false,
-                "disabled" if !state.disabled => return false,
-                "checked" if state.disabled || !state.checked => return false,
-                "focus" if state.disabled || !state.focused => return false,
-                "hover" if state.disabled || !state.hovered => return false,
-                "invalid" if !state.invalid => return false,
-                _ => {}
-            }
-        }
+fn selector_metadata(selector: &str) -> SelectorMetadata {
+    if let Some(cached) = SELECTOR_METADATA_CACHE
+        .read()
+        .ok()
+        .and_then(|cache| cache.get(selector).copied())
+    {
+        return cached;
     }
-    true
+
+    let metadata = compute_selector_metadata(selector);
+    if let Ok(mut cache) = SELECTOR_METADATA_CACHE.write() {
+        cache.insert(selector.to_string(), metadata);
+    }
+    metadata
 }
 
-/// Computes a simple specificity score for a selector.
-fn selector_specificity(selector: &str) -> u32 {
-    let mut spec = 0;
+fn compute_selector_metadata(selector: &str) -> SelectorMetadata {
+    if selector.contains("::") {
+        return SelectorMetadata {
+            skip: true,
+            ..Default::default()
+        };
+    }
+
+    let mut specificity = 0;
+    let mut pseudo_flags = 0;
+    let mut has_pseudo = false;
+
     for part in selector.replace('>', " > ").split_whitespace() {
         if part == ">" {
             continue;
         }
+
         let segments: Vec<&str> = part.split(':').collect();
         let base = segments[0];
 
-        spec += if base.starts_with('#') {
+        specificity += if base.starts_with('#') {
             100
         } else if base.starts_with('.') {
             10
-        } else if base == "*" {
+        } else if base == "*" || base.is_empty() {
             0
         } else {
             1
         };
 
-        spec += segments.len().saturating_sub(1) as u32;
+        if segments.len() > 1 {
+            has_pseudo = true;
+            specificity += segments.len().saturating_sub(1) as u32;
+        }
+
+        for pseudo in &segments[1..] {
+            match *pseudo {
+                "read-only" => pseudo_flags |= SELECTOR_READ_ONLY,
+                "disabled" => pseudo_flags |= SELECTOR_DISABLED,
+                "checked" => pseudo_flags |= SELECTOR_CHECKED,
+                "focus" => pseudo_flags |= SELECTOR_FOCUS,
+                "hover" => pseudo_flags |= SELECTOR_HOVER,
+                "invalid" => pseudo_flags |= SELECTOR_INVALID,
+                _ => {}
+            }
+        }
     }
-    spec
+
+    SelectorMetadata {
+        specificity,
+        pseudo_flags,
+        has_pseudo,
+        skip: false,
+    }
+}
+
+/// Returns true if the selector's cached pseudo state matches the widget state.
+fn selector_matches_state(metadata: SelectorMetadata, state: &UIWidgetState) -> bool {
+    if metadata.pseudo_flags & SELECTOR_READ_ONLY != 0 && !state.readonly {
+        return false;
+    }
+    if metadata.pseudo_flags & SELECTOR_DISABLED != 0 && !state.disabled {
+        return false;
+    }
+    if metadata.pseudo_flags & SELECTOR_CHECKED != 0 && (state.disabled || !state.checked) {
+        return false;
+    }
+    if metadata.pseudo_flags & SELECTOR_FOCUS != 0 && (state.disabled || !state.focused) {
+        return false;
+    }
+    if metadata.pseudo_flags & SELECTOR_HOVER != 0 && (state.disabled || !state.hovered) {
+        return false;
+    }
+    if metadata.pseudo_flags & SELECTOR_INVALID != 0 && !state.invalid {
+        return false;
+    }
+    true
 }
 
 /// Applies layout-related style fields to a Bevy `Node`.
@@ -2736,28 +2804,81 @@ fn folder_basename(folder: &str) -> &str {
         .unwrap_or(folder)
 }
 
-/// Propagates inheritable style fields down the widget tree.
+/// Propagates inheritable style fields only through subtrees that actually changed.
 pub fn propagate_style_inheritance(
     mut commands: Commands,
-    root_query: Query<Entity, (With<UiStyle>, Without<ChildOf>)>,
+    mut qs: ParamSet<(
+        Query<
+            Entity,
+            Or<(
+                Added<UiStyle>,
+                Changed<UiStyle>,
+                Added<StyleTransition>,
+                Changed<StyleTransition>,
+                Added<StyleAnimation>,
+                Changed<StyleAnimation>,
+                Added<ChildOf>,
+                Changed<ChildOf>,
+                Added<Text>,
+                Changed<Text>,
+                Added<TextColor>,
+                Added<TextFont>,
+                Added<LineHeight>,
+                Added<ImageNode>,
+                Added<TextShadow>,
+            )>,
+        >,
+        Query<(
+            Option<&mut TextColor>,
+            Option<&mut TextFont>,
+            Option<&mut LineHeight>,
+            Option<&mut ImageNode>,
+            Option<&mut TextShadow>,
+            Option<&mut Text>,
+            Option<&mut TextTransformState>,
+        )>,
+    )>,
+    parent_query: Query<&ChildOf>,
     children_query: Query<&Children>,
     style_query: Query<&UiStyle>,
     style_state_query: Query<(Option<&StyleTransition>, Option<&StyleAnimation>)>,
-    mut target_query: Query<(
-        Option<&mut TextColor>,
-        Option<&mut TextFont>,
-        Option<&mut LineHeight>,
-        Option<&mut ImageNode>,
-        Option<&mut TextShadow>,
-        Option<&mut Text>,
-        Option<&mut TextTransformState>,
-    )>,
     asset_server: Res<AssetServer>,
 ) {
-    for root_entity in root_query.iter() {
+    let dirty_entities: Vec<Entity> = qs.p0().iter().collect();
+    if dirty_entities.is_empty() {
+        return;
+    }
+
+    let dirty_set: HashSet<Entity> = dirty_entities.iter().copied().collect();
+    let mut target_query = qs.p1();
+
+    for entity in dirty_entities {
+        let mut current = entity;
+        let mut has_dirty_ancestor = false;
+
+        while let Ok(parent) = parent_query.get(current) {
+            let parent_entity = parent.parent();
+            if dirty_set.contains(&parent_entity) {
+                has_dirty_ancestor = true;
+                break;
+            }
+            current = parent_entity;
+        }
+
+        if has_dirty_ancestor {
+            continue;
+        }
+
+        let inherited_style = resolve_inherited_style_for_entity(
+            entity,
+            &parent_query,
+            &style_query,
+            &style_state_query,
+        );
+
         propagate_recursive(
-            root_entity,
-            None,
+            entity,
+            inherited_style.as_ref(),
             &mut commands,
             &children_query,
             &style_query,
@@ -2765,6 +2886,68 @@ pub fn propagate_style_inheritance(
             &mut target_query,
             &asset_server,
         );
+    }
+}
+
+fn resolve_inherited_style_for_entity(
+    entity: Entity,
+    parent_query: &Query<&ChildOf>,
+    style_query: &Query<&UiStyle>,
+    style_state_query: &Query<(Option<&StyleTransition>, Option<&StyleAnimation>)>,
+) -> Option<Style> {
+    let mut lineage = Vec::new();
+    let mut current = entity;
+
+    while let Ok(parent) = parent_query.get(current) {
+        let parent_entity = parent.parent();
+        lineage.push(parent_entity);
+        current = parent_entity;
+    }
+
+    if lineage.is_empty() {
+        return None;
+    }
+
+    let mut inherited_style = Style::default();
+    let mut has_inherited = false;
+
+    for ancestor in lineage.into_iter().rev() {
+        merge_entity_style_for_propagation(
+            ancestor,
+            &mut inherited_style,
+            style_query,
+            style_state_query,
+        );
+        has_inherited = true;
+    }
+
+    has_inherited.then_some(inherited_style)
+}
+
+fn merge_entity_style_for_propagation(
+    entity: Entity,
+    style_to_propagate: &mut Style,
+    style_query: &Query<&UiStyle>,
+    style_state_query: &Query<(Option<&StyleTransition>, Option<&StyleAnimation>)>,
+) {
+    if let Ok(ui_style) = style_query.get(entity) {
+        if let Some(active_style) = ui_style.active_style.as_ref() {
+            style_to_propagate.merge(active_style);
+        }
+    }
+
+    if let Ok((transition_opt, animation_opt)) = style_state_query.get(entity) {
+        if let Some(transition) = transition_opt {
+            if let Some(current) = &transition.current_style {
+                style_to_propagate.merge(current);
+            }
+        }
+
+        if let Some(animation) = animation_opt {
+            if let Some(current) = &animation.current_style {
+                style_to_propagate.merge(current);
+            }
+        }
     }
 }
 
@@ -2790,28 +2973,13 @@ fn propagate_recursive(
     let my_style_comp = style_query.get(entity).ok();
     let my_active_style = my_style_comp.and_then(|s| s.active_style.as_ref());
 
-    let mut style_to_propagate = if let Some(inherited) = inherited_style {
-        inherited.clone()
-    } else {
-        Style::default()
-    };
-
-    if let Some(mine) = my_active_style {
-        style_to_propagate.merge(mine);
-    }
-
-    if let Ok((transition_opt, animation_opt)) = style_state_query.get(entity) {
-        if let Some(transition) = transition_opt {
-            if let Some(current) = &transition.current_style {
-                style_to_propagate.merge(current);
-            }
-        }
-        if let Some(animation) = animation_opt {
-            if let Some(current) = &animation.current_style {
-                style_to_propagate.merge(current);
-            }
-        }
-    }
+    let mut style_to_propagate = inherited_style.cloned().unwrap_or_default();
+    merge_entity_style_for_propagation(
+        entity,
+        &mut style_to_propagate,
+        style_query,
+        style_state_query,
+    );
 
     if let Ok((
         mut text_color_opt,

--- a/src/services/unit_tests.rs
+++ b/src/services/unit_tests.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use super::super::css_service::{CssService, CssUsers};
+    use super::super::css_service::{
+        CssService, CssUsers, collect_assets_with_changed_media_matches,
+    };
     use super::super::image_service::{get_or_load_image, pre_load_assets};
     use super::super::state_service::{StateService, update_widget_states};
     use super::super::style_service::{
@@ -16,7 +18,7 @@ mod tests {
     use bevy::input::ButtonInput;
     use bevy::prelude::*;
     use bevy::text::LineHeight;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -383,6 +385,44 @@ mod tests {
     }
 
     #[test]
+    fn css_service_collects_only_assets_with_changed_media_matches() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, AssetPlugin::default()));
+        app.init_asset::<CssAsset>();
+
+        let responsive_entity = app.world_mut().spawn_empty().id();
+        let static_entity = app.world_mut().spawn_empty().id();
+
+        let (responsive_css, static_css) = {
+            let mut assets = app.world_mut().resource_mut::<Assets<CssAsset>>();
+            (
+                assets.add(CssAsset {
+                    text: "@media (max-width: 500px) { .card { color: red; } }".to_string(),
+                }),
+                assets.add(CssAsset {
+                    text: ".card { color: blue; }".to_string(),
+                }),
+            )
+        };
+
+        let mut css_users = CssUsers::default();
+        css_users.users = HashMap::from([
+            (responsive_css.id(), HashSet::from([responsive_entity])),
+            (static_css.id(), HashSet::from([static_entity])),
+        ]);
+
+        let affected = collect_assets_with_changed_media_matches(
+            &css_users,
+            app.world().resource::<Assets<CssAsset>>(),
+            Vec2::new(800.0, 600.0),
+            Vec2::new(400.0, 600.0),
+        );
+
+        assert!(affected.contains(&responsive_css.id()));
+        assert!(!affected.contains(&static_css.id()));
+    }
+
+    #[test]
     fn css_service_updates_css_users_index_for_added_and_changed_sources() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, AssetPlugin::default(), CssService));
@@ -665,6 +705,65 @@ mod tests {
 
         assert_eq!(text_color.0, Color::srgb(1.0, 0.0, 0.0));
         assert_eq!(image_node.color, Color::srgb(0.2, 0.3, 0.4));
+    }
+
+    #[test]
+    fn update_widget_styles_system_prefers_hover_pseudo_styles_when_state_matches() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, AssetPlugin::default()));
+        app.init_asset::<Image>();
+        app.insert_resource(ImageCache::default());
+        app.add_systems(Update, update_widget_styles_system);
+
+        let mut base_style = Style::default();
+        base_style.color = Some(Color::srgb(0.2, 0.2, 1.0));
+
+        let mut hover_style = Style::default();
+        hover_style.color = Some(Color::srgb(1.0, 0.5, 0.0));
+
+        let mut styles = HashMap::new();
+        styles.insert(
+            "button".to_string(),
+            StylePair {
+                normal: base_style,
+                selector: "button".to_string(),
+                ..default()
+            },
+        );
+        styles.insert(
+            "button:hover".to_string(),
+            StylePair {
+                normal: hover_style,
+                selector: "button:hover".to_string(),
+                ..default()
+            },
+        );
+
+        let entity = app
+            .world_mut()
+            .spawn((
+                UiStyle {
+                    css: Handle::default(),
+                    styles,
+                    keyframes: HashMap::new(),
+                    active_style: None,
+                },
+                UIWidgetState {
+                    hovered: true,
+                    ..default()
+                },
+                Node::default(),
+                TextColor(Color::NONE),
+            ))
+            .id();
+
+        app.update();
+
+        let text_color = app
+            .world()
+            .get::<TextColor>(entity)
+            .expect("missing TextColor");
+        assert_eq!(text_color.0, Color::srgb(1.0, 0.5, 0.0));
     }
 
     #[test]

--- a/src/widgets/body.rs
+++ b/src/widgets/body.rs
@@ -5,7 +5,7 @@ use crate::registry::UiRegistry;
 use crate::styles::{CssClass, CssSource, Style, TagName};
 use crate::widgets::controls::choice_box::ChoiceLayoutBoxBase;
 use crate::widgets::div::DivContentRoot;
-use crate::widgets::widget_util::wheel_delta_y;
+use crate::widgets::widget_util::{wheel_delta_x, wheel_delta_y};
 use crate::widgets::{
     ActiveScrollTarget, BindToID, Body, Div, Scrollbar, UIGenID, UIWidgetState, WidgetId,
     WidgetKind,
@@ -648,9 +648,10 @@ fn route_hover_from_pointer_messages(
     }
 }
 
-/// Wheel scroll uses the "last hovered body" and scrolls its BodyScrollContent (Y only).
+/// Wheel scroll uses the "last hovered body" and scrolls its BodyScrollContent on both axes.
 fn handle_body_scroll_wheel(
     mut wheel_events: MessageReader<MouseWheel>,
+    keyboard: Option<Res<ButtonInput<KeyCode>>>,
     active_scroll_target: Option<Res<ActiveScrollTarget>>,
     hovered: Res<HoveredBodyTracker>,
     body_q: Query<(Entity, &BodyContentRoot), With<Body>>,
@@ -684,16 +685,25 @@ fn handle_body_scroll_wheel(
             return false;
         };
 
-        if node.overflow.y != OverflowAxis::Scroll {
-            return false;
-        }
-
         let inv_sf = computed.inverse_scale_factor.max(f32::EPSILON);
-        let viewport_h = (computed.size().y * inv_sf).max(1.0);
-        let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
-        let max_scroll = (content_h - viewport_h).max(0.0);
 
-        max_scroll > 0.5
+        let can_scroll_y = if node.overflow.y == OverflowAxis::Scroll {
+            let viewport_h = (computed.size().y * inv_sf).max(1.0);
+            let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
+            (content_h - viewport_h).max(0.0) > 0.5
+        } else {
+            false
+        };
+
+        let can_scroll_x = if node.overflow.x == OverflowAxis::Scroll {
+            let viewport_w = (computed.size().x * inv_sf).max(1.0);
+            let content_w = (computed.content_size.x * inv_sf).max(viewport_w);
+            (content_w - viewport_w).max(0.0) > 0.5
+        } else {
+            false
+        };
+
+        can_scroll_x || can_scroll_y
     });
     if has_hovered_scrollable_div {
         return;
@@ -710,16 +720,25 @@ fn handle_body_scroll_wheel(
                 if !matches!(*visibility, Visibility::Visible | Visibility::Inherited) {
                     return false;
                 }
-                if node.overflow.y != OverflowAxis::Scroll {
-                    return false;
-                }
-
                 let inv_sf = computed.inverse_scale_factor.max(f32::EPSILON);
-                let viewport_h = (computed.size().y * inv_sf).max(1.0);
-                let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
-                let max_scroll = (content_h - viewport_h).max(0.0);
 
-                max_scroll > 0.5
+                let can_scroll_y = if node.overflow.y == OverflowAxis::Scroll {
+                    let viewport_h = (computed.size().y * inv_sf).max(1.0);
+                    let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
+                    (content_h - viewport_h).max(0.0) > 0.5
+                } else {
+                    false
+                };
+
+                let can_scroll_x = if node.overflow.x == OverflowAxis::Scroll {
+                    let viewport_w = (computed.size().x * inv_sf).max(1.0);
+                    let content_w = (computed.content_size.x * inv_sf).max(viewport_w);
+                    (content_w - viewport_w).max(0.0) > 0.5
+                } else {
+                    false
+                };
+
+                can_scroll_x || can_scroll_y
             });
     if has_hovered_scrollable_choice_overlay {
         return;
@@ -754,18 +773,38 @@ fn handle_body_scroll_wheel(
             continue;
         };
 
-        if node.overflow.y != OverflowAxis::Scroll {
+        let can_scroll_y = node.overflow.y == OverflowAxis::Scroll;
+        let can_scroll_x = node.overflow.x == OverflowAxis::Scroll;
+        if !can_scroll_x && !can_scroll_y {
             continue;
         }
 
         let inv_sf = computed.inverse_scale_factor.max(f32::EPSILON);
-        let delta = -wheel_delta_y(event, inv_sf);
+        let shift = keyboard.as_ref().is_some_and(|keys| {
+            keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight)
+        });
 
-        let viewport_h = (computed.size().y * inv_sf).max(1.0);
-        let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
-        let max_scroll = (content_h - viewport_h).max(0.0);
+        let mut delta_x = -wheel_delta_x(event, inv_sf);
+        let mut delta_y = -wheel_delta_y(event, inv_sf);
 
-        scroll.y = (scroll.y + delta).clamp(0.0, max_scroll);
+        if shift && delta_x.abs() <= f32::EPSILON && can_scroll_x {
+            delta_x = delta_y;
+            delta_y = 0.0;
+        }
+
+        if can_scroll_y && delta_y.abs() > f32::EPSILON {
+            let viewport_h = (computed.size().y * inv_sf).max(1.0);
+            let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
+            let max_scroll_y = (content_h - viewport_h).max(0.0);
+            scroll.y = (scroll.y + delta_y).clamp(0.0, max_scroll_y);
+        }
+
+        if can_scroll_x && delta_x.abs() > f32::EPSILON {
+            let viewport_w = (computed.size().x * inv_sf).max(1.0);
+            let content_w = (computed.content_size.x * inv_sf).max(viewport_w);
+            let max_scroll_x = (content_w - viewport_w).max(0.0);
+            scroll.x = (scroll.x + delta_x).clamp(0.0, max_scroll_x);
+        }
     }
 }
 
@@ -977,6 +1016,15 @@ mod tests {
         }
     }
 
+    fn line_wheel_xy(x: f32, y: f32) -> MouseWheel {
+        MouseWheel {
+            unit: MouseScrollUnit::Line,
+            x,
+            y,
+            window: Entity::PLACEHOLDER,
+        }
+    }
+
     fn spawn_body_scroll_content(world: &mut World, viewport_h: f32, content_h: f32) -> Entity {
         let mut node = Node::default();
         node.overflow = Overflow {
@@ -989,6 +1037,23 @@ mod tests {
                 BodyScrollContent,
                 node,
                 computed_node(Vec2::new(200.0, viewport_h), Vec2::new(200.0, content_h)),
+                ScrollPosition::default(),
+            ))
+            .id()
+    }
+
+    fn spawn_body_scroll_content_xy(world: &mut World, viewport: Vec2, content: Vec2) -> Entity {
+        let mut node = Node::default();
+        node.overflow = Overflow {
+            x: OverflowAxis::Scroll,
+            y: OverflowAxis::Hidden,
+        };
+
+        world
+            .spawn((
+                BodyScrollContent,
+                node,
+                computed_node(viewport, content),
                 ScrollPosition::default(),
             ))
             .id()
@@ -1078,6 +1143,72 @@ mod tests {
             .get::<ScrollPosition>(content_entity)
             .expect("body scroll content is missing ScrollPosition");
         assert_eq!(pos.y, 25.0);
+    }
+
+    #[test]
+    fn body_wheel_scroll_moves_body_content_horizontally_when_x_wheel_is_used() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<Messages<MouseWheel>>();
+        app.insert_resource(HoveredBodyTracker::default());
+        app.add_systems(Update, handle_body_scroll_wheel);
+
+        let content_entity =
+            spawn_body_scroll_content_xy(app.world_mut(), Vec2::new(100.0, 80.0), Vec2::new(260.0, 80.0));
+        let body_entity = app
+            .world_mut()
+            .spawn((Body::default(), BodyContentRoot(content_entity)))
+            .id();
+        app.world_mut()
+            .resource_mut::<HoveredBodyTracker>()
+            .last_body = Some(body_entity);
+
+        app.world_mut()
+            .resource_mut::<Messages<MouseWheel>>()
+            .write(line_wheel_xy(-1.0, 0.0));
+        app.update();
+
+        let pos = app
+            .world()
+            .get::<ScrollPosition>(content_entity)
+            .expect("body scroll content is missing ScrollPosition");
+        assert_eq!(pos.x, 25.0);
+        assert_eq!(pos.y, 0.0);
+    }
+
+    #[test]
+    fn body_wheel_scroll_uses_shift_vertical_wheel_for_horizontal_scroll() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<Messages<MouseWheel>>();
+        app.insert_resource(ButtonInput::<KeyCode>::default());
+        app.insert_resource(HoveredBodyTracker::default());
+        app.add_systems(Update, handle_body_scroll_wheel);
+
+        let content_entity =
+            spawn_body_scroll_content_xy(app.world_mut(), Vec2::new(100.0, 80.0), Vec2::new(260.0, 80.0));
+        let body_entity = app
+            .world_mut()
+            .spawn((Body::default(), BodyContentRoot(content_entity)))
+            .id();
+        app.world_mut()
+            .resource_mut::<HoveredBodyTracker>()
+            .last_body = Some(body_entity);
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .press(KeyCode::ShiftLeft);
+
+        app.world_mut()
+            .resource_mut::<Messages<MouseWheel>>()
+            .write(line_wheel(-1.0));
+        app.update();
+
+        let pos = app
+            .world()
+            .get::<ScrollPosition>(content_entity)
+            .expect("body scroll content is missing ScrollPosition");
+        assert_eq!(pos.x, 25.0);
+        assert_eq!(pos.y, 0.0);
     }
 
     #[test]

--- a/src/widgets/body.rs
+++ b/src/widgets/body.rs
@@ -7,7 +7,8 @@ use crate::widgets::controls::choice_box::ChoiceLayoutBoxBase;
 use crate::widgets::div::DivContentRoot;
 use crate::widgets::widget_util::wheel_delta_y;
 use crate::widgets::{
-    BindToID, Body, Div, Scrollbar, UIGenID, UIWidgetState, WidgetId, WidgetKind,
+    ActiveScrollTarget, BindToID, Body, Div, Scrollbar, UIGenID, UIWidgetState, WidgetId,
+    WidgetKind,
 };
 use crate::{CurrentWidgetState, ExtendedUiConfiguration};
 use bevy::camera::visibility::RenderLayers;
@@ -649,6 +650,7 @@ fn route_hover_from_pointer_messages(
 /// Wheel scroll uses the "last hovered body" and scrolls its BodyScrollContent (Y only).
 fn handle_body_scroll_wheel(
     mut wheel_events: MessageReader<MouseWheel>,
+    active_scroll_target: Res<ActiveScrollTarget>,
     hovered: Res<HoveredBodyTracker>,
     body_q: Query<(Entity, &BodyContentRoot), With<Body>>,
     mut content_q: Query<(&Node, &ComputedNode, &mut ScrollPosition), With<BodyScrollContent>>,
@@ -663,6 +665,11 @@ fn handle_body_scroll_wheel(
     >,
     dialog_overlay_q: Query<(Option<&TagName>, Option<&CssClass>, &Visibility)>,
 ) {
+    if active_scroll_target.entity.is_some() {
+        wheel_events.clear();
+        return;
+    }
+
     // Scrollable div under the pointer has priority over body scrolling.
     let has_hovered_scrollable_div = div_q.iter().any(|(state, root)| {
         if !state.hovered {

--- a/src/widgets/body.rs
+++ b/src/widgets/body.rs
@@ -78,6 +78,7 @@ impl Plugin for BodyWidget {
     /// Registers systems for body widget setup.
     fn build(&self, app: &mut App) {
         app.init_resource::<HoveredBodyTracker>();
+        app.init_resource::<ActiveScrollTarget>();
         app.add_systems(
             Update,
             (
@@ -650,7 +651,7 @@ fn route_hover_from_pointer_messages(
 /// Wheel scroll uses the "last hovered body" and scrolls its BodyScrollContent (Y only).
 fn handle_body_scroll_wheel(
     mut wheel_events: MessageReader<MouseWheel>,
-    active_scroll_target: Res<ActiveScrollTarget>,
+    active_scroll_target: Option<Res<ActiveScrollTarget>>,
     hovered: Res<HoveredBodyTracker>,
     body_q: Query<(Entity, &BodyContentRoot), With<Body>>,
     mut content_q: Query<(&Node, &ComputedNode, &mut ScrollPosition), With<BodyScrollContent>>,
@@ -665,7 +666,10 @@ fn handle_body_scroll_wheel(
     >,
     dialog_overlay_q: Query<(Option<&TagName>, Option<&CssClass>, &Visibility)>,
 ) {
-    if active_scroll_target.entity.is_some() {
+    if active_scroll_target
+        .as_ref()
+        .is_some_and(|target| target.entity.is_some())
+    {
         wheel_events.clear();
         return;
     }

--- a/src/widgets/content/divider.rs
+++ b/src/widgets/content/divider.rs
@@ -28,18 +28,25 @@ impl Plugin for DividerWidget {
 /// Spawns the divider UI node with initial alignment classes.
 fn internal_node_creation_system(
     mut commands: Commands,
-    query: Query<(Entity, &Divider, Option<&CssSource>), (With<Divider>, Without<DividerBase>)>,
+    query: Query<
+        (Entity, &Divider, Option<&CssSource>, Option<&CssClass>),
+        (With<Divider>, Without<DividerBase>),
+    >,
     config: Res<ExtendedUiConfiguration>,
 ) {
     let layer = config.render_layers.first().unwrap_or(&1);
 
-    for (entity, divider, source_opt) in query.iter() {
+    for (entity, divider, source_opt, class_opt) in query.iter() {
         let mut css_source = CssSource::default();
         if let Some(source) = source_opt {
             css_source = source.clone();
         }
 
         let align_class = alignment_class(&divider.alignment);
+        let mut classes = class_opt.map(|c| c.0.clone()).unwrap_or_default();
+        if !classes.iter().any(|c| c == align_class) {
+            classes.push(align_class.to_string());
+        }
 
         commands.entity(entity).insert((
             Name::new(format!("Divider-{}", divider.entry)),
@@ -54,7 +61,7 @@ fn internal_node_creation_system(
             BorderColor::default(),
             css_source,
             TagName("divider".to_string()),
-            CssClass(vec![align_class.to_string()]),
+            CssClass(classes),
             RenderLayers::layer(*layer),
             DividerBase,
             PrevDividerAlignment(divider.alignment.clone()),

--- a/src/widgets/controls/choice_box.rs
+++ b/src/widgets/controls/choice_box.rs
@@ -601,7 +601,7 @@ fn on_layout_cursor_leave(
 ///
 /// This system:
 /// - Updates the selected state across all sibling options (only one is `checked = true`).
-/// - Updates the parent [`ChoiceBox`] value with the clicked option's text/icon.
+/// - Updates the parent [`ChoiceBox`] value with the full clicked option, including typed value.
 /// - Closes the dropdown (`open = false`).
 /// - Updates any [`SelectedOptionBase`] display widgets with the new value.
 /// - Optionally removes focus from the clicked option if no value was selected.
@@ -617,7 +617,7 @@ fn on_layout_cursor_leave(
 /// - Optional: `UIWidgetState::focused`
 /// Handles clicks on choice box options to update selection.
 fn on_internal_option_click(
-    trigger: On<Pointer<Click>>,
+    mut trigger: On<Pointer<Click>>,
     mut option_query: Query<
         (
             Entity,
@@ -638,16 +638,15 @@ fn on_internal_option_click(
 ) {
     let clicked_entity = trigger.entity;
 
-    let (clicked_parent_id, clicked_option_text, clicked_option_icon) =
+    let (clicked_parent_id, clicked_option) =
         if let Ok((_, _, option, bind_id, _)) = option_query.get(clicked_entity) {
-            (
-                bind_id.0.clone(),
-                option.text.clone(),
-                option.icon_path.clone(),
-            )
+            (bind_id.0, option.clone())
         } else {
             return;
         };
+
+    let clicked_option_text = clicked_option.text.clone();
+    let clicked_option_icon = clicked_option.icon_path.clone();
 
     for (entity, mut state, _, bind_id, children) in option_query.iter_mut() {
         if bind_id.0 == clicked_parent_id {
@@ -663,8 +662,7 @@ fn on_internal_option_click(
 
     for (_, mut parent_state, id, mut choice_box) in parent_query.iter_mut() {
         if id.0 == clicked_parent_id {
-            choice_box.value.text = clicked_option_text.clone();
-            choice_box.value.icon_path = clicked_option_icon.clone();
+            choice_box.value = clicked_option.clone();
             parent_state.open = false;
 
             if clicked_option_text.is_empty() && clicked_option_icon.is_none() {
@@ -684,6 +682,8 @@ fn on_internal_option_click(
             }
         }
     }
+
+    trigger.propagate(false);
 }
 
 /// Sets `hovered = true` on a [`ChoiceOptionBase`] and its visual children when hovered.

--- a/src/widgets/controls/choice_box.rs
+++ b/src/widgets/controls/choice_box.rs
@@ -196,8 +196,8 @@ fn internal_node_creation_system(
 
                         for option in choice_box.options.iter() {
                             let is_selected = if !selected_assigned {
-                                if choice_box.value.value_as_str().map_or(false, |s| !s.is_empty()) {
-                                    choice_box.value.value_as_str() == option.value_as_str()
+                                if choice_box.value.value.as_str().map_or(false, |s| !s.is_empty()) {
+                                    choice_box.value.value.as_str() == option.value.as_str()
                                 } else if !choice_box.value.text.is_empty() {
                                     choice_box.value.text == option.text
                                 } else {

--- a/src/widgets/controls/choice_box.rs
+++ b/src/widgets/controls/choice_box.rs
@@ -194,8 +194,8 @@ fn internal_node_creation_system(
 
                         for option in choice_box.options.iter() {
                             let is_selected = if !selected_assigned {
-                                if !choice_box.value.internal_value.is_empty() {
-                                    choice_box.value.internal_value == option.internal_value
+                                if choice_box.value.value_as_str().map_or(false, |s| !s.is_empty()) {
+                                    choice_box.value.value_as_str() == option.value_as_str()
                                 } else if !choice_box.value.text.is_empty() {
                                     choice_box.value.text == option.text
                                 } else {

--- a/src/widgets/controls/choice_box.rs
+++ b/src/widgets/controls/choice_box.rs
@@ -4,14 +4,15 @@ use crate::styles::paint::Colored;
 use crate::styles::{CssClass, CssSource, FontVal, TagName};
 use crate::widgets::widget_util::wheel_delta_y;
 use crate::widgets::{
-    BindToID, ChoiceBox, ChoiceOption, IgnoreParentState, UIGenID, UIWidgetState, WidgetId,
-    WidgetKind,
+    ActiveScrollTarget, BindToID, ChoiceBox, ChoiceOption, IgnoreParentState, UIGenID,
+    UIWidgetState, WidgetId, WidgetKind,
 };
 use crate::{CurrentWidgetState, ExtendedUiConfiguration, ImageCache};
 use bevy::camera::visibility::RenderLayers;
 use bevy::ecs::relationship::RelatedSpawnerCommands;
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
+use bevy::ui::RelativeCursorPosition;
 
 const CHOICE_BOX_OVERLAY_ROOT_Z: i32 = 40_000;
 const CHOICE_BOX_OVERLAY_CONTENT_Z: i32 = 40_001;
@@ -182,6 +183,7 @@ fn internal_node_creation_system(
                         CssClass(vec![String::from("choice-content-box")]),
                         RenderLayers::layer(*layer),
                         Visibility::Hidden,
+                        RelativeCursorPosition::default(),
                         ChoiceLayoutBoxBase,
                         BindToID(id.0),
                     ))
@@ -436,6 +438,7 @@ fn update_content_box_visibility(
 /// Handles mouse wheel scrolling within the dropdown content.
 fn handle_scroll_events(
     mut scroll_events: MessageReader<MouseWheel>,
+    active_scroll_target: Res<ActiveScrollTarget>,
     mut layout_query: Query<
         (
             Entity,
@@ -443,6 +446,7 @@ fn handle_scroll_events(
             &Children,
             &mut ScrollPosition,
             &ComputedNode,
+            &RelativeCursorPosition,
         ),
         With<ChoiceLayoutBoxBase>,
     >,
@@ -452,11 +456,15 @@ fn handle_scroll_events(
     let smooth_factor = 30.0;
 
     for event in scroll_events.read() {
-        for (layout_entity, visibility, children, mut scroll, layout_computed) in
+        for (layout_entity, visibility, children, mut scroll, layout_computed, cursor_pos) in
             layout_query.iter_mut()
         {
             let is_visible = matches!(*visibility, Visibility::Visible | Visibility::Inherited);
-            if !is_visible {
+            if !is_visible || cursor_pos.normalized.is_none() {
+                continue;
+            }
+
+            if active_scroll_target.entity != Some(layout_entity) {
                 continue;
             }
 
@@ -579,9 +587,11 @@ fn on_internal_cursor_leave(
 fn on_layout_cursor_entered(
     trigger: On<Pointer<Over>>,
     mut query: Query<&mut UIWidgetState, With<ChoiceLayoutBoxBase>>,
+    mut active_scroll_target: ResMut<ActiveScrollTarget>,
 ) {
     if let Ok(mut state) = query.get_mut(trigger.entity) {
         state.hovered = true;
+        active_scroll_target.entity = Some(trigger.entity);
     }
 }
 
@@ -589,9 +599,13 @@ fn on_layout_cursor_entered(
 fn on_layout_cursor_leave(
     trigger: On<Pointer<Out>>,
     mut query: Query<&mut UIWidgetState, With<ChoiceLayoutBoxBase>>,
+    mut active_scroll_target: ResMut<ActiveScrollTarget>,
 ) {
     if let Ok(mut state) = query.get_mut(trigger.entity) {
         state.hovered = false;
+        if active_scroll_target.entity == Some(trigger.entity) {
+            active_scroll_target.entity = None;
+        }
     }
 }
 
@@ -635,6 +649,7 @@ fn on_internal_option_click(
     mut selected_query: Query<(&BindToID, &Children), With<SelectedOptionBase>>,
     mut text_query: Query<&mut Text>,
     mut inner_query: Query<&mut UIWidgetState, (Without<ChoiceOptionBase>, Without<ChoiceBox>)>,
+    mut active_scroll_target: ResMut<ActiveScrollTarget>,
 ) {
     let clicked_entity = trigger.entity;
 
@@ -664,6 +679,7 @@ fn on_internal_option_click(
         if id.0 == clicked_parent_id {
             choice_box.value = clicked_option.clone();
             parent_state.open = false;
+            active_scroll_target.entity = None;
 
             if clicked_option_text.is_empty() && clicked_option_icon.is_none() {
                 if let Ok((_, mut state, _, _, _)) = option_query.get_mut(clicked_entity) {

--- a/src/widgets/controls/list_box.rs
+++ b/src/widgets/controls/list_box.rs
@@ -3,13 +3,14 @@ use crate::styles::paint::Colored;
 use crate::styles::{CssClass, CssSource, TagName};
 use crate::widgets::widget_util::wheel_delta_y;
 use crate::widgets::{
-    BindToID, ChoiceOption, IgnoreParentState, ListBox, UIGenID, UIWidgetState, WidgetId,
-    WidgetKind,
+    ActiveScrollTarget, BindToID, ChoiceOption, IgnoreParentState, ListBox, UIGenID,
+    UIWidgetState, WidgetId, WidgetKind,
 };
 use crate::{CurrentWidgetState, ExtendedUiConfiguration, ImageCache};
 use bevy::camera::visibility::RenderLayers;
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
+use bevy::ui::RelativeCursorPosition;
 
 /// Marker component for initialized list box widgets.
 #[derive(Component)]
@@ -82,6 +83,7 @@ fn internal_node_creation_system(
                 TagName("listbox".to_string()),
                 RenderLayers::layer(*layer),
                 ScrollPosition::default(),
+                RelativeCursorPosition::default(),
                 ListBoxBase,
             ))
             .insert(GlobalZIndex::default())
@@ -182,6 +184,7 @@ fn internal_node_creation_system(
 /// Enables mouse-wheel scrolling within a [`ListBox`].
 fn handle_scroll_events(
     mut scroll_events: MessageReader<MouseWheel>,
+    active_scroll_target: Res<ActiveScrollTarget>,
     mut layout_query: Query<
         (
             Entity,
@@ -189,6 +192,7 @@ fn handle_scroll_events(
             &Children,
             &mut ScrollPosition,
             &ComputedNode,
+            &RelativeCursorPosition,
         ),
         With<ListBoxBase>,
     >,
@@ -198,11 +202,15 @@ fn handle_scroll_events(
     let smooth_factor = 30.0;
 
     for event in scroll_events.read() {
-        for (layout_entity, visibility, children, mut scroll, layout_computed) in
+        for (layout_entity, visibility, children, mut scroll, layout_computed, cursor_pos) in
             layout_query.iter_mut()
         {
             let is_visible = matches!(*visibility, Visibility::Visible | Visibility::Inherited);
-            if !is_visible {
+            if !is_visible || cursor_pos.normalized.is_none() {
+                continue;
+            }
+
+            if active_scroll_target.entity != Some(layout_entity) {
                 continue;
             }
 
@@ -257,9 +265,11 @@ fn on_internal_click(
 fn on_internal_cursor_entered(
     mut trigger: On<Pointer<Over>>,
     mut query: Query<&mut UIWidgetState, With<ListBox>>,
+    mut active_scroll_target: ResMut<ActiveScrollTarget>,
 ) {
     if let Ok(mut state) = query.get_mut(trigger.entity) {
         state.hovered = true;
+        active_scroll_target.entity = Some(trigger.entity);
     }
 
     trigger.propagate(false);
@@ -269,9 +279,13 @@ fn on_internal_cursor_entered(
 fn on_internal_cursor_leave(
     mut trigger: On<Pointer<Out>>,
     mut query: Query<&mut UIWidgetState, With<ListBox>>,
+    mut active_scroll_target: ResMut<ActiveScrollTarget>,
 ) {
     if let Ok(mut state) = query.get_mut(trigger.entity) {
         state.hovered = false;
+        if active_scroll_target.entity == Some(trigger.entity) {
+            active_scroll_target.entity = None;
+        }
     }
 
     trigger.propagate(false);

--- a/src/widgets/controls/list_box.rs
+++ b/src/widgets/controls/list_box.rs
@@ -1,0 +1,384 @@
+use crate::services::image_service::get_or_load_image;
+use crate::styles::paint::Colored;
+use crate::styles::{CssClass, CssSource, TagName};
+use crate::widgets::widget_util::wheel_delta_y;
+use crate::widgets::{
+    BindToID, ChoiceOption, IgnoreParentState, ListBox, UIGenID, UIWidgetState, WidgetId,
+    WidgetKind,
+};
+use crate::{CurrentWidgetState, ExtendedUiConfiguration, ImageCache};
+use bevy::camera::visibility::RenderLayers;
+use bevy::input::mouse::MouseWheel;
+use bevy::prelude::*;
+
+/// Marker component for initialized list box widgets.
+#[derive(Component)]
+struct ListBoxBase;
+
+/// Marker component for individual list box option entries.
+#[derive(Component)]
+pub(crate) struct ListBoxOptionBase;
+
+/// Plugin that registers list box widget behavior.
+pub struct ListBoxWidget;
+
+impl Plugin for ListBoxWidget {
+    /// Registers systems for list box setup and interaction.
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (internal_node_creation_system, handle_scroll_events).chain(),
+        );
+    }
+}
+
+/// System that initializes internal UI nodes for [`ListBox`] components.
+///
+/// Builds a scrollable list of option entries. Each option is always visible
+/// (unlike `ChoiceBox` which hides options behind a dropdown).
+///
+/// Supports `multiselect`: clicking an option toggles it.
+/// In single-select mode clicking an option deselects any previously selected one.
+fn internal_node_creation_system(
+    mut commands: Commands,
+    query: Query<
+        (Entity, &UIGenID, &ListBox, Option<&CssSource>),
+        (With<ListBox>, Without<ListBoxBase>),
+    >,
+    config: Res<ExtendedUiConfiguration>,
+    asset_server: Res<AssetServer>,
+    mut image_cache: ResMut<ImageCache>,
+    mut images: ResMut<Assets<Image>>,
+) {
+    let layer = config.render_layers.first().unwrap_or(&1);
+    for (entity, id, list_box, source_opt) in query.iter() {
+        let mut css_source = CssSource::default();
+        if let Some(source) = source_opt {
+            css_source = source.clone();
+        }
+
+        commands
+            .entity(entity)
+            .insert((
+                Name::new(format!("List-Box-{}", list_box.entry)),
+                Node::default(),
+                WidgetId {
+                    id: list_box.entry,
+                    kind: WidgetKind::ListBox,
+                },
+                BackgroundColor::default(),
+                ImageNode::default(),
+                BorderColor::default(),
+                BoxShadow::new(
+                    Colored::TRANSPARENT,
+                    Val::Px(0.),
+                    Val::Px(0.),
+                    Val::Px(0.),
+                    Val::Px(0.),
+                ),
+                ZIndex::default(),
+                Pickable::default(),
+                css_source.clone(),
+                TagName("listbox".to_string()),
+                RenderLayers::layer(*layer),
+                ScrollPosition::default(),
+                ListBoxBase,
+            ))
+            .insert(GlobalZIndex::default())
+            .observe(on_internal_click)
+            .observe(on_internal_cursor_entered)
+            .observe(on_internal_cursor_leave)
+            .with_children(|builder| {
+                for option in list_box.options.iter() {
+                    let is_selected = list_box.values.contains(option);
+
+                    let state = UIWidgetState {
+                        checked: is_selected,
+                        ..default()
+                    };
+
+                    builder
+                        .spawn((
+                            Name::new(format!("ListBox-Option-{}", list_box.entry)),
+                            Node::default(),
+                            BackgroundColor::default(),
+                            ImageNode::default(),
+                            BorderColor::default(),
+                            ZIndex::default(),
+                            state.clone(),
+                            IgnoreParentState,
+                            option.clone(),
+                            css_source.clone(),
+                            CssClass(vec![String::from("listbox-option")]),
+                            RenderLayers::layer(*layer),
+                            ListBoxOptionBase,
+                            BindToID(id.0),
+                        ))
+                        .observe(on_option_click)
+                        .observe(on_option_cursor_entered)
+                        .observe(on_option_cursor_leave)
+                        .with_children(|builder| {
+                            if let Some(icon_path) = option.icon_path.as_deref() {
+                                let handle = get_or_load_image(
+                                    icon_path,
+                                    &mut image_cache,
+                                    &mut images,
+                                    &asset_server,
+                                );
+
+                                builder.spawn((
+                                    Name::new(format!(
+                                        "ListBox-Option-Icon-{}",
+                                        list_box.entry
+                                    )),
+                                    ImageNode {
+                                        image: handle,
+                                        ..default()
+                                    },
+                                    ZIndex::default(),
+                                    state.clone(),
+                                    IgnoreParentState,
+                                    css_source.clone(),
+                                    CssClass(vec![
+                                        String::from("option-icon"),
+                                        String::from("option-text"),
+                                    ]),
+                                    Pickable::IGNORE,
+                                    RenderLayers::layer(*layer),
+                                    BindToID(id.0),
+                                ));
+                            }
+
+                            let text = if option.text.trim().is_empty() {
+                                Text::new("(empty)")
+                            } else {
+                                Text::new(option.text.clone())
+                            };
+
+                            builder.spawn((
+                                Name::new(format!(
+                                    "ListBox-Option-Text-{}",
+                                    list_box.entry
+                                )),
+                                text,
+                                TextColor::default(),
+                                TextFont::default(),
+                                TextLayout::default(),
+                                ZIndex::default(),
+                                state.clone(),
+                                IgnoreParentState,
+                                css_source.clone(),
+                                CssClass(vec![String::from("option-text")]),
+                                Pickable::IGNORE,
+                                RenderLayers::layer(*layer),
+                                BindToID(id.0),
+                            ));
+                        });
+                }
+            });
+    }
+}
+
+/// Enables mouse-wheel scrolling within a [`ListBox`].
+fn handle_scroll_events(
+    mut scroll_events: MessageReader<MouseWheel>,
+    mut layout_query: Query<
+        (
+            Entity,
+            &Visibility,
+            &Children,
+            &mut ScrollPosition,
+            &ComputedNode,
+        ),
+        With<ListBoxBase>,
+    >,
+    option_query: Query<(&ComputedNode, &ChildOf), With<ListBoxOptionBase>>,
+    time: Res<Time>,
+) {
+    let smooth_factor = 30.0;
+
+    for event in scroll_events.read() {
+        for (layout_entity, visibility, children, mut scroll, layout_computed) in
+            layout_query.iter_mut()
+        {
+            let is_visible = matches!(*visibility, Visibility::Visible | Visibility::Inherited);
+            if !is_visible {
+                continue;
+            }
+
+            let inv_sf = layout_computed.inverse_scale_factor.max(f32::EPSILON);
+            let delta = -wheel_delta_y(event, inv_sf);
+
+            if children.is_empty() {
+                scroll.y = 0.0;
+                continue;
+            }
+
+            let mut option_height = None;
+            for (opt_computed, parent) in option_query.iter() {
+                if parent.parent() == layout_entity {
+                    let opt_inv_sf = opt_computed.inverse_scale_factor.max(f32::EPSILON);
+                    option_height = Some((opt_computed.size().y * opt_inv_sf).max(1.0));
+                    break;
+                }
+            }
+
+            let option_h = option_height.unwrap_or(40.0);
+            let measured_viewport = (layout_computed.size().y * inv_sf).max(1.0);
+            let content_h = children.len() as f32 * option_h;
+            let max_scroll = (content_h - measured_viewport).max(0.0);
+
+            let target = (scroll.y + delta).clamp(0.0, max_scroll);
+            let smoothed = scroll.y + (target - scroll.y) * smooth_factor * time.delta_secs();
+            scroll.y = smoothed.clamp(0.0, max_scroll);
+        }
+    }
+}
+
+// ===============================================
+//                   Intern Events
+// ===============================================
+
+/// Handles click events on the [`ListBox`] background (focus tracking).
+fn on_internal_click(
+    mut trigger: On<Pointer<Click>>,
+    mut query: Query<(&mut UIWidgetState, &UIGenID), With<ListBox>>,
+    mut current_widget_state: ResMut<CurrentWidgetState>,
+) {
+    if let Ok((mut state, gen_id)) = query.get_mut(trigger.entity) {
+        state.focused = true;
+        current_widget_state.widget_id = gen_id.0;
+    }
+
+    trigger.propagate(false);
+}
+
+/// Sets `hovered = true` on a [`ListBox`] when the cursor enters.
+fn on_internal_cursor_entered(
+    mut trigger: On<Pointer<Over>>,
+    mut query: Query<&mut UIWidgetState, With<ListBox>>,
+) {
+    if let Ok(mut state) = query.get_mut(trigger.entity) {
+        state.hovered = true;
+    }
+
+    trigger.propagate(false);
+}
+
+/// Sets `hovered = false` on a [`ListBox`] when the cursor leaves.
+fn on_internal_cursor_leave(
+    mut trigger: On<Pointer<Out>>,
+    mut query: Query<&mut UIWidgetState, With<ListBox>>,
+) {
+    if let Ok(mut state) = query.get_mut(trigger.entity) {
+        state.hovered = false;
+    }
+
+    trigger.propagate(false);
+}
+
+/// Handles selection when a list box option is clicked.
+///
+/// In multiselect mode the option's `checked` state is toggled.
+/// In single-select mode all other options are unchecked and the clicked one is checked.
+fn on_option_click(
+    mut trigger: On<Pointer<Click>>,
+    mut option_query: Query<
+        (Entity, &mut UIWidgetState, &ChoiceOption, &BindToID, &Children),
+        With<ListBoxOptionBase>,
+    >,
+    mut parent_query: Query<(&UIGenID, &mut ListBox), Without<ListBoxOptionBase>>,
+    mut inner_query: Query<&mut UIWidgetState, (Without<ListBoxOptionBase>, Without<ListBox>)>,
+) {
+    let clicked_entity = trigger.entity;
+
+    let (clicked_parent_id, _clicked_option, was_checked) =
+        if let Ok((_, state, option, bind_id, _)) = option_query.get(clicked_entity) {
+            (bind_id.0, option.clone(), state.checked)
+        } else {
+            return;
+        };
+
+    // Find the parent list box to read multiselect flag.
+    let multiselect = parent_query
+        .iter()
+        .find(|(id, _)| id.0 == clicked_parent_id)
+        .map(|(_, lb)| lb.multiselect)
+        .unwrap_or(false);
+
+    // Update checked states on all sibling options.
+    for (entity, mut state, _, bind_id, children) in option_query.iter_mut() {
+        if bind_id.0 != clicked_parent_id {
+            continue;
+        }
+
+        let new_checked = if multiselect {
+            // toggle only the clicked option
+            if entity == clicked_entity {
+                !was_checked
+            } else {
+                state.checked
+            }
+        } else {
+            // single-select: only the clicked option becomes checked
+            entity == clicked_entity
+        };
+
+        state.checked = new_checked;
+
+        for child in children.iter() {
+            if let Ok(mut inner_state) = inner_query.get_mut(child) {
+                inner_state.checked = new_checked;
+            }
+        }
+    }
+
+    // Rebuild values on the parent ListBox.
+    for (id, mut list_box) in parent_query.iter_mut() {
+        if id.0 != clicked_parent_id {
+            continue;
+        }
+
+        list_box.values = option_query
+            .iter()
+            .filter(|(_, state, _, bind_id, _)| bind_id.0 == clicked_parent_id && state.checked)
+            .map(|(_, _, option, _, _)| option.clone())
+            .collect();
+    }
+
+    trigger.propagate(false);
+}
+
+/// Sets `hovered = true` on a list box option and its visual children.
+fn on_option_cursor_entered(
+    trigger: On<Pointer<Over>>,
+    mut query: Query<(&mut UIWidgetState, &Children), With<ListBoxOptionBase>>,
+    mut inner_query: Query<&mut UIWidgetState, Without<ListBoxOptionBase>>,
+) {
+    if let Ok((mut state, children)) = query.get_mut(trigger.entity) {
+        state.hovered = true;
+
+        for child in children.iter() {
+            if let Ok(mut inner_state) = inner_query.get_mut(child) {
+                inner_state.hovered = true;
+            }
+        }
+    }
+}
+
+/// Sets `hovered = false` on a list box option and its visual children.
+fn on_option_cursor_leave(
+    trigger: On<Pointer<Out>>,
+    mut query: Query<(&mut UIWidgetState, &Children), With<ListBoxOptionBase>>,
+    mut inner_query: Query<&mut UIWidgetState, Without<ListBoxOptionBase>>,
+) {
+    if let Ok((mut state, children)) = query.get_mut(trigger.entity) {
+        state.hovered = false;
+
+        for child in children.iter() {
+            if let Ok(mut inner_state) = inner_query.get_mut(child) {
+                inner_state.hovered = false;
+            }
+        }
+    }
+}

--- a/src/widgets/controls/mod.rs
+++ b/src/widgets/controls/mod.rs
@@ -8,6 +8,7 @@ use crate::widgets::controls::color_picker::ColorPickerWidget;
 use crate::widgets::controls::date_picker::DatePickerWidget;
 use crate::widgets::controls::fieldset::FieldSetWidget;
 use crate::widgets::controls::input::InputWidget;
+use crate::widgets::controls::list_box::ListBoxWidget;
 use crate::widgets::controls::progress_bar::ProgressBarWidget;
 use crate::widgets::controls::radio_button::RadioButtonWidget;
 use crate::widgets::controls::scroll_bar::ScrollWidget;
@@ -26,6 +27,7 @@ pub mod color_picker;
 pub mod date_picker;
 pub mod fieldset;
 pub mod input;
+pub mod list_box;
 mod progress_bar;
 pub mod radio_button;
 mod scroll_bar;
@@ -51,6 +53,7 @@ impl Plugin for ExtendedControlWidgets {
             DatePickerWidget,
             FieldSetWidget,
             InputWidget,
+            ListBoxWidget,
             ProgressBarWidget,
             RadioButtonWidget,
             ScrollWidget,

--- a/src/widgets/controls/scroll_bar.rs
+++ b/src/widgets/controls/scroll_bar.rs
@@ -55,17 +55,22 @@ impl Plugin for ScrollWidget {
 /// Initializes UI nodes for scrollbar widgets.
 fn internal_node_creation_system(
     mut commands: Commands,
-    query: Query<(Entity, &Scrollbar, Option<&CssSource>), (With<Scrollbar>, Without<ScrollBase>)>,
+    query: Query<
+        (Entity, &Scrollbar, Option<&CssSource>, Option<&CssClass>),
+        (With<Scrollbar>, Without<ScrollBase>),
+    >,
     config: Res<ExtendedUiConfiguration>,
 ) {
     let layer = *config.render_layers.first().unwrap_or(&1);
 
-    for (entity, scroll, source_opt) in query.iter() {
+    for (entity, scroll, source_opt, class_opt) in query.iter() {
         let css_source = source_opt.cloned().unwrap_or_default();
 
-        let mut class = CssClass(vec![]);
+        let mut classes = class_opt.map(|class| class.0.clone()).unwrap_or_default();
         if !scroll.vertical {
-            class = CssClass(vec!["scroll-horizontal".into()]);
+            if !classes.iter().any(|class| class == "scroll-horizontal") {
+                classes.push("scroll-horizontal".to_string());
+            }
         }
         commands
             .entity(entity)
@@ -80,7 +85,7 @@ fn internal_node_creation_system(
                 BorderColor::default(),
                 ZIndex::default(),
                 css_source.clone(),
-                class,
+                CssClass(classes),
                 PreviousScrollState {
                     value: scroll.value,
                     max: scroll.max,

--- a/src/widgets/controls/slider.rs
+++ b/src/widgets/controls/slider.rs
@@ -362,6 +362,7 @@ fn spawn_thumb(
             ),
         ))
         .observe(on_thumb_drag)
+        .observe(on_thumb_click)
         .observe(on_thumb_over)
         .observe(on_thumb_out)
         .with_children(|builder| {
@@ -609,7 +610,7 @@ fn apply_from_track_pointer(
 
 /// Handles dragging the slider thumb to update value.
 fn on_thumb_drag(
-    event: On<Pointer<Drag>>,
+    mut event: On<Pointer<Drag>>,
     parent_q: Query<&ChildOf>,
     track_q: Query<(&ComputedNode, &BindToID), With<SliderTrackContainer>>,
     thumb_node_q: Query<&ComputedNode, With<SliderThumb>>,
@@ -673,6 +674,14 @@ fn on_thumb_drag(
         &mut fill_q,
         &mut thumb_q,
     );
+
+    // Prevent thumb drags from bubbling to the track drag observer.
+    event.propagate(false);
+}
+
+/// Stops thumb click events from reaching the track.
+fn on_thumb_click(mut event: On<Pointer<Click>>) {
+    event.propagate(false);
 }
 
 /// Tracks thumb hover state.
@@ -721,29 +730,55 @@ fn apply_from_track_left_x(
 
         sanitize_slider(&mut slider);
 
-        let role = resolve_target_role(
-            &slider,
-            preferred_role,
-            desired_left_x,
-            track_width,
-            thumb_width,
-            ui_id.0,
-            thumb_q,
-        );
-
         let next_value = value_from_left(desired_left_x, track_width, thumb_width, &slider);
         match slider.slider_type {
             SliderType::Default => {
                 slider.value = next_value;
             }
-            SliderType::Range => match role {
-                SliderThumbRole::Start => {
-                    slider.range_start = next_value.min(slider.range_end);
+            SliderType::Range => {
+                if preferred_role.is_none() {
+                    // Track interactions move the full selected span.
+                    let current_center = (slider.range_start + slider.range_end) * 0.5;
+                    let delta = next_value - current_center;
+                    let span = slider.range_end - slider.range_start;
+                    let max_start = (slider.max - span).max(slider.min);
+
+                    let mut next_start = slider.range_start + delta;
+                    let mut next_end = slider.range_end + delta;
+
+                    if next_start < slider.min {
+                        let shift = slider.min - next_start;
+                        next_start += shift;
+                        next_end += shift;
+                    }
+                    if next_end > slider.max {
+                        let shift = next_end - slider.max;
+                        next_start -= shift;
+                    }
+
+                    slider.range_start = next_start.clamp(slider.min, max_start);
+                    slider.range_end = slider.range_start + span;
+                } else {
+                    let role = resolve_target_role(
+                        &slider,
+                        preferred_role,
+                        desired_left_x,
+                        track_width,
+                        thumb_width,
+                        ui_id.0,
+                        thumb_q,
+                    );
+
+                    match role {
+                        SliderThumbRole::Start => {
+                            slider.range_start = next_value.min(slider.range_end - slider.step);
+                        }
+                        SliderThumbRole::End => {
+                            slider.range_end = next_value.max(slider.range_start + slider.step);
+                        }
+                    }
                 }
-                SliderThumbRole::End => {
-                    slider.range_end = next_value.max(slider.range_start);
-                }
-            },
+            }
         }
 
         apply_slider_visual_state(

--- a/src/widgets/default_style.rs
+++ b/src/widgets/default_style.rs
@@ -1086,6 +1086,78 @@ select {
     }
 }
 
+/* ListBox */
+
+listbox {
+    width: 200px;
+    height: 150px;
+    border-radius: 5px 0;
+    border: 2px;
+    border-color: var(--text-color);
+    color: var(--text-color);
+    font-size: 14px;
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    transition: all 0.3s;
+
+    &:disabled {
+        border-color: var(--disabled-text);
+        color: var(--disabled-text);
+    }
+
+    &:hover {
+        border-color: var(--primary-hover);
+    }
+
+    &:focus {
+        border-color: var(--primary);
+    }
+
+    > .listbox-option {
+        width: 100%;
+        height: 40px;
+        min-height: 40px;
+        max-height: 40px;
+        padding-left: 10px;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        flex-direction: row;
+        gap: 10px;
+        background: var(--gray-background);
+        transition: all 0.3s;
+
+        > .option-text {
+            transition: all 0.3s;
+
+            &:hover {
+                color: var(--text-color);
+            }
+
+            &:checked {
+                color: var(--text-color);
+            }
+        }
+
+        &:hover {
+            background: var(--primary-hover);
+        }
+
+        &:checked {
+            background: var(--primary);
+        }
+
+        &:disabled {
+            color: var(--disabled-text);
+            background: var(--gray-background);
+        }
+    }
+}
+
 /* Slider */
 
 slider {

--- a/src/widgets/div.rs
+++ b/src/widgets/div.rs
@@ -422,6 +422,7 @@ fn route_hover_from_pointer_messages(
     sb_owner_q: Query<&DivScrollbarOwner>,
     is_scroll_content_q: Query<(), With<DivScrollContent>>,
     mut div_state_q: Query<&mut UIWidgetState, With<Div>>,
+    div_with_scroll_q: Query<&DivContentRoot, With<Div>>,
     mut hovered: ResMut<HoveredDivTracker>,
 ) {
     /// Walks up the hierarchy to find the owning div entity.
@@ -456,6 +457,22 @@ fn route_hover_from_pointer_messages(
         }
     }
 
+    /// Finds all ancestor Div entities up the parent chain.
+    fn find_all_ancestor_divs(
+        mut e: Entity,
+        parents: &Query<&ChildOf>,
+        is_div_q: &Query<(), With<Div>>,
+    ) -> Vec<Entity> {
+        let mut ancestors = Vec::new();
+        while let Ok(p) = parents.get(e) {
+            e = p.parent();
+            if is_div_q.get(e).is_ok() {
+                ancestors.push(e);
+            }
+        }
+        ancestors
+    }
+
     for msg in over.read() {
         let Some(div) = find_owner_div(
             msg.entity,
@@ -470,11 +487,35 @@ fn route_hover_from_pointer_messages(
 
         let d = hovered.div_ref.entry(div).or_insert(0);
         *d = d.saturating_add(1);
-        hovered.last_div = Some(div);
 
         if let Ok(mut state) = div_state_q.get_mut(div) {
             state.hovered = true;
         }
+
+        // Also mark all ancestor divs as hovered for nested div support
+        let ancestors = find_all_ancestor_divs(div, &parents, &is_div_q);
+
+        // Find the closest (deepest/most recent) scrollable div in the hierarchy for last_div.
+        // Prefer scrollable ancestors over non-scrollable children for wheel event handling.
+        let mut scrollable_div = None;
+        if div_with_scroll_q.get(div).is_ok() {
+            scrollable_div = Some(div);
+        }
+        for ancestor_div in &ancestors {
+            let d = hovered.div_ref.entry(*ancestor_div).or_insert(0);
+            *d = d.saturating_add(1);
+
+            if let Ok(mut state) = div_state_q.get_mut(*ancestor_div) {
+                state.hovered = true;
+            }
+
+            // Use the first scrollable ancestor found (closest parent)
+            if scrollable_div.is_none() && div_with_scroll_q.get(*ancestor_div).is_ok() {
+                scrollable_div = Some(*ancestor_div);
+            }
+        }
+
+        hovered.last_div = scrollable_div.or(Some(div));
     }
 
     for msg in out.read() {
@@ -500,6 +541,25 @@ fn route_hover_from_pointer_messages(
 
                 if hovered.last_div == Some(div) {
                     hovered.last_div = hovered.div_ref.keys().next().copied();
+                }
+            }
+        }
+
+        // Also unmark ancestor divs
+        let ancestors = find_all_ancestor_divs(div, &parents, &is_div_q);
+        for ancestor_div in ancestors {
+            if let Some(d) = hovered.div_ref.get_mut(&ancestor_div) {
+                *d = d.saturating_sub(1);
+                if *d == 0 {
+                    hovered.div_ref.remove(&ancestor_div);
+
+                    if let Ok(mut state) = div_state_q.get_mut(ancestor_div) {
+                        state.hovered = false;
+                    }
+
+                    if hovered.last_div == Some(ancestor_div) {
+                        hovered.last_div = hovered.div_ref.keys().next().copied();
+                    }
                 }
             }
         }

--- a/src/widgets/div.rs
+++ b/src/widgets/div.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use crate::styles::paint::Colored;
 use crate::styles::{CssClass, CssSource, TagName};
 use crate::widgets::widget_util::wheel_delta_y;
-use crate::widgets::{BindToID, Div, Scrollbar, UIGenID, UIWidgetState, WidgetId, WidgetKind};
+use crate::widgets::{
+    ActiveScrollTarget, BindToID, Div, Scrollbar, UIGenID, UIWidgetState, WidgetId, WidgetKind,
+};
 use crate::{CurrentWidgetState, ExtendedUiConfiguration};
 use bevy::camera::visibility::RenderLayers;
 use bevy::input::mouse::MouseWheel;
@@ -508,10 +510,16 @@ fn route_hover_from_pointer_messages(
 /// Handles mouse wheel scrolling for div content.
 fn handle_div_scroll_wheel(
     mut wheel_events: MessageReader<MouseWheel>,
+    active_scroll_target: Res<ActiveScrollTarget>,
     hovered: Res<HoveredDivTracker>,
     div_q: Query<(&DivContentRoot, &Visibility), With<Div>>,
     mut content_q: Query<(&Node, &ComputedNode, &mut ScrollPosition), With<DivScrollContent>>,
 ) {
+    if active_scroll_target.entity.is_some() {
+        wheel_events.clear();
+        return;
+    }
+
     let Some(active_div) = hovered.last_div else {
         wheel_events.clear();
         return;

--- a/src/widgets/div.rs
+++ b/src/widgets/div.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::styles::paint::Colored;
 use crate::styles::{CssClass, CssSource, TagName};
-use crate::widgets::widget_util::wheel_delta_y;
+use crate::widgets::widget_util::{wheel_delta_x, wheel_delta_y};
 use crate::widgets::{
     ActiveScrollTarget, BindToID, Div, Scrollbar, UIGenID, UIWidgetState, WidgetId, WidgetKind,
 };
@@ -566,10 +566,11 @@ fn route_hover_from_pointer_messages(
     }
 }
 
-/// Wheel scroll uses the "last hovered div" and scrolls its DivScrollContent (Y only).
+/// Wheel scroll uses the "last hovered div" and scrolls its DivScrollContent on both axes.
 /// Handles mouse wheel scrolling for div content.
 fn handle_div_scroll_wheel(
     mut wheel_events: MessageReader<MouseWheel>,
+    keyboard: Option<Res<ButtonInput<KeyCode>>>,
     active_scroll_target: Res<ActiveScrollTarget>,
     hovered: Res<HoveredDivTracker>,
     div_q: Query<(&DivContentRoot, &Visibility), With<Div>>,
@@ -598,18 +599,38 @@ fn handle_div_scroll_wheel(
             continue;
         };
 
-        if node.overflow.y != OverflowAxis::Scroll {
+        let can_scroll_y = node.overflow.y == OverflowAxis::Scroll;
+        let can_scroll_x = node.overflow.x == OverflowAxis::Scroll;
+        if !can_scroll_x && !can_scroll_y {
             continue;
         }
 
         let inv_sf = computed.inverse_scale_factor.max(f32::EPSILON);
-        let delta = -wheel_delta_y(event, inv_sf);
+        let shift = keyboard.as_ref().is_some_and(|keys| {
+            keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight)
+        });
 
-        let viewport_h = (computed.size().y * inv_sf).max(1.0);
-        let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
-        let max_scroll = (content_h - viewport_h).max(0.0);
+        let mut delta_x = -wheel_delta_x(event, inv_sf);
+        let mut delta_y = -wheel_delta_y(event, inv_sf);
 
-        scroll.y = (scroll.y + delta).clamp(0.0, max_scroll);
+        if shift && delta_x.abs() <= f32::EPSILON && can_scroll_x {
+            delta_x = delta_y;
+            delta_y = 0.0;
+        }
+
+        if can_scroll_y && delta_y.abs() > f32::EPSILON {
+            let viewport_h = (computed.size().y * inv_sf).max(1.0);
+            let content_h = (computed.content_size.y * inv_sf).max(viewport_h);
+            let max_scroll_y = (content_h - viewport_h).max(0.0);
+            scroll.y = (scroll.y + delta_y).clamp(0.0, max_scroll_y);
+        }
+
+        if can_scroll_x && delta_x.abs() > f32::EPSILON {
+            let viewport_w = (computed.size().x * inv_sf).max(1.0);
+            let content_w = (computed.content_size.x * inv_sf).max(viewport_w);
+            let max_scroll_x = (content_w - viewport_w).max(0.0);
+            scroll.x = (scroll.x + delta_x).clamp(0.0, max_scroll_x);
+        }
     }
 }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -16,7 +16,9 @@ use crate::widgets::controls::ExtendedControlWidgets;
 use crate::widgets::div::DivWidget;
 use crate::widgets::form::FormWidget;
 use bevy::prelude::*;
+use std::any::Any;
 use std::fmt;
+use std::sync::Arc;
 
 pub(crate) use validation::evaluate_validation_state;
 
@@ -447,32 +449,100 @@ impl Default for ChoiceBox {
 }
 
 /// Single option entry used by choice boxes.
-#[derive(Component, Reflect, Debug, Clone, PartialEq, Eq)]
+#[derive(Component, Reflect, Debug, Clone)]
 pub struct ChoiceOption {
     pub text: String,
-    pub internal_value: String,
+    /// The option's value. Defaults to a `String` but can hold any `Send + Sync` type.
+    /// Use [`ChoiceOption::with_value`] to attach a typed value and
+    /// [`ChoiceOption::get_value`] to recover it. Use [`ChoiceOption::value_as_str`]
+    /// for the common `String` case.
+    #[reflect(ignore)]
+    pub internal_value: Option<Arc<dyn Any + Send + Sync>>,
     pub icon_path: Option<String>,
 }
+
+impl PartialEq for ChoiceOption {
+    fn eq(&self, other: &Self) -> bool {
+        if self.text != other.text || self.icon_path != other.icon_path {
+            return false;
+        }
+        match (&self.internal_value, &other.internal_value) {
+            (None, None) => true,
+            (Some(a), Some(b)) => match (a.downcast_ref::<String>(), b.downcast_ref::<String>()) {
+                (Some(sa), Some(sb)) => sa == sb,
+                _ => Arc::ptr_eq(a, b),
+            },
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ChoiceOption {}
 
 impl Default for ChoiceOption {
     /// Creates a default option labeled "Please Select".
     fn default() -> Self {
         Self {
             text: String::from("Please Select"),
-            internal_value: String::from("default"),
+            internal_value: Some(Arc::new(String::from("default"))),
             icon_path: None,
         }
     }
 }
 
 impl ChoiceOption {
-    /// Creates an option using the provided text.
+    /// Creates an option using the provided text as the internal string value.
     pub fn new(text: &str) -> Self {
         Self {
             text: text.to_string(),
-            internal_value: text.trim().to_string(),
+            internal_value: Some(Arc::new(text.trim().to_string())),
             icon_path: None,
         }
+    }
+
+    /// Replaces the internal value with an arbitrary typed value.
+    pub fn with_value<T: Any + Send + Sync>(mut self, value: T) -> Self {
+        self.internal_value = Some(Arc::new(value));
+        self
+    }
+
+    /// Downcasts the internal value to `T`, returning `None` if absent or the type mismatches.
+    pub fn get_value<T: Any>(&self) -> Option<&T> {
+        self.internal_value.as_ref()?.downcast_ref::<T>()
+    }
+
+    /// Returns the internal value as a `&str` if it is a `String`, otherwise `None`.
+    pub fn value_as_str(&self) -> Option<&str> {
+        self.internal_value.as_ref()?.downcast_ref::<String>().map(|s| s.as_str())
+    }
+
+    /// Returns the internal value as a [`ReflectedValue`] if it was deserialized via Bevy
+    /// reflection, allowing further downcasting with Bevy's reflect API.
+    pub fn get_reflected(&self) -> Option<&ReflectedValue> {
+        self.get_value::<ReflectedValue>()
+    }
+}
+
+/// Wraps a `Box<dyn PartialReflect>` so it can be stored as `Arc<dyn Any + Send + Sync>` and
+/// retrieved via [`ChoiceOption::get_reflected`].
+///
+/// Use [`ReflectedValue::downcast_ref`] to obtain the concrete type.
+///
+/// # Example
+/// ```ignore
+/// if let Some(rv) = option.get_reflected() {
+///     if let Some(my_val) = rv.downcast_ref::<MyStruct>() { ... }
+/// }
+/// ```
+pub struct ReflectedValue(pub Box<dyn PartialReflect>);
+
+impl ReflectedValue {
+    /// Downcasts the inner reflected value to `T`.
+    ///
+    /// Returns `None` if the concrete type doesn't implement the full [`Reflect`] trait or
+    /// if the type doesn't match.
+    pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.0.try_as_reflect()?.as_any().downcast_ref::<T>()
     }
 }
 
@@ -1245,7 +1315,12 @@ impl Default for ProgressBar {
 pub struct RadioButton {
     pub entry: usize,
     pub label: String,
-    pub value: String,
+    /// The button's value. Defaults to an empty `String` but can hold any `Send + Sync` type.
+    /// Use [`RadioButton::with_value`] to attach a typed value and
+    /// [`RadioButton::get_value`] to recover it. Use [`RadioButton::value_as_str`]
+    /// for the common `String` case.
+    #[reflect(ignore)]
+    pub value: Option<Arc<dyn Any + Send + Sync>>,
     pub selected: bool,
 }
 
@@ -1257,9 +1332,32 @@ impl Default for RadioButton {
         Self {
             entry,
             label: String::from("label"),
-            value: String::from(""),
+            value: Some(Arc::new(String::from(""))),
             selected: false,
         }
+    }
+}
+
+impl RadioButton {
+    /// Replaces the value with an arbitrary typed value.
+    pub fn with_value<T: Any + Send + Sync>(mut self, value: T) -> Self {
+        self.value = Some(Arc::new(value));
+        self
+    }
+
+    /// Downcasts the value to `T`, returning `None` if absent or the type mismatches.
+    pub fn get_value<T: Any>(&self) -> Option<&T> {
+        self.value.as_ref()?.downcast_ref::<T>()
+    }
+
+    /// Returns the value as a `&str` if it is a `String`, otherwise `None`.
+    pub fn value_as_str(&self) -> Option<&str> {
+        self.value.as_ref()?.downcast_ref::<String>().map(|s| s.as_str())
+    }
+
+    /// Returns the value as a [`ReflectedValue`] if it was deserialized via Bevy reflection.
+    pub fn get_reflected(&self) -> Option<&ReflectedValue> {
+        self.get_value::<ReflectedValue>()
     }
 }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -465,7 +465,7 @@ pub struct ChoiceOption {
     /// [`ChoiceOption::get_value`] to recover it. Use [`ChoiceOption::value_as_str`]
     /// for the common `String` case.
     #[reflect(ignore)]
-    pub internal_value: Option<Arc<dyn Any + Send + Sync>>,
+    pub value: WidgetValue,
     pub icon_path: Option<String>,
 }
 
@@ -474,7 +474,7 @@ impl PartialEq for ChoiceOption {
         if self.text != other.text || self.icon_path != other.icon_path {
             return false;
         }
-        match (&self.internal_value, &other.internal_value) {
+        match (&self.value.0, &other.value.0) {
             (None, None) => true,
             (Some(a), Some(b)) => match (a.downcast_ref::<String>(), b.downcast_ref::<String>()) {
                 (Some(sa), Some(sb)) => sa == sb,
@@ -492,7 +492,7 @@ impl Default for ChoiceOption {
     fn default() -> Self {
         Self {
             text: String::from("Please Select"),
-            internal_value: Some(Arc::new(String::from("default"))),
+            value: WidgetValue::new(String::from("default")),
             icon_path: None,
         }
     }
@@ -503,31 +503,30 @@ impl ChoiceOption {
     pub fn new(text: &str) -> Self {
         Self {
             text: text.to_string(),
-            internal_value: Some(Arc::new(text.trim().to_string())),
+            value: WidgetValue::new(text.trim().to_string()),
             icon_path: None,
         }
     }
 
-    /// Replaces the internal value with an arbitrary typed value.
+    /// Sets a typed value for this option.
     pub fn with_value<T: Any + Send + Sync>(mut self, value: T) -> Self {
-        self.internal_value = Some(Arc::new(value));
+        self.value.set(value);
         self
     }
 
-    /// Downcasts the internal value to `T`, returning `None` if absent or the type mismatches.
+    /// Returns the typed value if it can be downcast to `T`.
     pub fn get_value<T: Any>(&self) -> Option<&T> {
-        self.internal_value.as_ref()?.downcast_ref::<T>()
+        self.value.get::<T>()
     }
 
-    /// Returns the internal value as a `&str` if it is a `String`, otherwise `None`.
+    /// Returns the internal value as `&str` when it holds a `String`.
     pub fn value_as_str(&self) -> Option<&str> {
-        self.internal_value.as_ref()?.downcast_ref::<String>().map(|s| s.as_str())
+        self.value.as_str()
     }
 
-    /// Returns the internal value as a [`ReflectedValue`] if it was deserialized via Bevy
-    /// reflection, allowing further downcasting with Bevy's reflect API.
+    /// Returns a reflected value when the option was created from reflection.
     pub fn get_reflected(&self) -> Option<&ReflectedValue> {
-        self.get_value::<ReflectedValue>()
+        self.value.reflect()
     }
 }
 
@@ -1367,7 +1366,7 @@ pub struct RadioButton {
     /// [`RadioButton::get_value`] to recover it. Use [`RadioButton::value_as_str`]
     /// for the common `String` case.
     #[reflect(ignore)]
-    pub value: Option<Arc<dyn Any + Send + Sync>>,
+    pub value: WidgetValue,
     pub selected: bool,
 }
 
@@ -1379,32 +1378,63 @@ impl Default for RadioButton {
         Self {
             entry,
             label: String::from("label"),
-            value: Some(Arc::new(String::from(""))),
+            value: WidgetValue::new(String::new()),
             selected: false,
         }
     }
 }
 
 impl RadioButton {
-    /// Replaces the value with an arbitrary typed value.
+    /// Sets a typed value for this radio button.
     pub fn with_value<T: Any + Send + Sync>(mut self, value: T) -> Self {
-        self.value = Some(Arc::new(value));
+        self.value.set(value);
         self
     }
 
-    /// Downcasts the value to `T`, returning `None` if absent or the type mismatches.
+    /// Returns the typed value if it can be downcast to `T`.
     pub fn get_value<T: Any>(&self) -> Option<&T> {
-        self.value.as_ref()?.downcast_ref::<T>()
+        self.value.get::<T>()
     }
 
-    /// Returns the value as a `&str` if it is a `String`, otherwise `None`.
+    /// Returns the internal value as `&str` when it holds a `String`.
     pub fn value_as_str(&self) -> Option<&str> {
-        self.value.as_ref()?.downcast_ref::<String>().map(|s| s.as_str())
+        self.value.as_str()
     }
 
-    /// Returns the value as a [`ReflectedValue`] if it was deserialized via Bevy reflection.
+    /// Returns a reflected value when the radio value was created from reflection.
     pub fn get_reflected(&self) -> Option<&ReflectedValue> {
-        self.get_value::<ReflectedValue>()
+        self.value.reflect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WidgetValue(Option<Arc<dyn Any + Send + Sync>>);
+
+impl Default for WidgetValue {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl WidgetValue {
+    pub fn new<T: Any + Send + Sync>(value: T) -> Self {
+        Self(Some(Arc::new(value)))
+    }
+
+    pub fn get<T: Any>(&self) -> Option<&T> {
+        self.0.as_ref()?.downcast_ref::<T>()
+    }
+
+    pub fn set<T: Any + Send + Sync>(&mut self, value: T) {
+        self.0 = Some(Arc::new(value));
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        self.0.as_ref()?.downcast_ref::<String>().map(|s| s.as_str())
+    }
+
+    pub fn reflect(&self) -> Option<&ReflectedValue> {
+        self.get::<ReflectedValue>()
     }
 }
 
@@ -1710,7 +1740,8 @@ impl Default for SwitchButton {
 pub struct ToggleButton {
     pub entry: usize,
     pub label: String,
-    pub value: String,
+    #[reflect(ignore)]
+    pub value: WidgetValue,
     pub icon_place: IconPlace,
     pub icon_path: Option<String>,
     pub selected: bool,
@@ -1724,7 +1755,7 @@ impl Default for ToggleButton {
         Self {
             entry,
             label: String::from("label"),
-            value: String::from(""),
+            value: WidgetValue::new(String::from("")),
             icon_path: None,
             icon_place: IconPlace::default(),
             selected: false,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -28,6 +28,12 @@ pub(crate) use validation::evaluate_validation_state;
 #[derive(Component)]
 pub struct IgnoreParentState;
 
+/// Tracks the currently hovered scrollable widget so wheel input is routed once.
+#[derive(Resource, Default)]
+pub(crate) struct ActiveScrollTarget {
+    pub entity: Option<Entity>,
+}
+
 /// Unique identifier for UI elements.
 ///
 /// Each UI element should have a unique `UIGenID` generated atomically.
@@ -222,6 +228,7 @@ pub struct ExtendedWidgetPlugin;
 impl Plugin for ExtendedWidgetPlugin {
     /// Registers widget components and systems.
     fn build(&self, app: &mut App) {
+        app.init_resource::<ActiveScrollTarget>();
         app.register_type::<UIGenID>();
         app.register_type::<BindToID>();
         app.register_type::<UIWidgetState>();

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -213,6 +213,7 @@ pub enum WidgetKind {
     Slider,
     SwitchButton,
     ToggleButton,
+    ListBox,
 }
 
 /// Plugin that registers all built-in widget types.
@@ -543,6 +544,45 @@ impl ReflectedValue {
     /// if the type doesn't match.
     pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
         self.0.try_as_reflect()?.as_any().downcast_ref::<T>()
+    }
+}
+
+// ===============================================
+//                    ListBox
+// ===============================================
+
+/// List box widget displaying all options in a scrollable list.
+///
+/// Unlike [`ChoiceBox`], all options are always visible (no dropdown).
+/// Supports both single-select and multiselect modes via [`ListBox::multiselect`].
+#[derive(Component, Reflect, Debug, Clone)]
+#[reflect(Component)]
+#[require(UIGenID, UIWidgetState, Widget)]
+pub struct ListBox {
+    pub entry: usize,
+    pub options: Vec<ChoiceOption>,
+    /// Currently selected options. In single-select mode this holds at most one entry.
+    pub values: Vec<ChoiceOption>,
+    /// When `true`, clicking options toggles their selection independently.
+    /// When `false`, only one option can be selected at a time.
+    pub multiselect: bool,
+}
+
+impl Default for ListBox {
+    /// Creates a default list box widget with no pre-selected options.
+    fn default() -> Self {
+        let entry = LIST_BOX_ID_POOL.lock().unwrap().acquire();
+
+        Self {
+            entry,
+            options: vec![
+                ChoiceOption::new("Option A"),
+                ChoiceOption::new("Option B"),
+                ChoiceOption::new("Option C"),
+            ],
+            values: Vec::new(),
+            multiselect: false,
+        }
     }
 }
 

--- a/src/widgets/unit_tests.rs
+++ b/src/widgets/unit_tests.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::super::controls::{ButtonImage, place_icon_if};
     use super::super::validation::update_validation_states;
-    use super::super::widget_util::wheel_delta_y;
+    use super::super::widget_util::{wheel_delta_x, wheel_delta_y};
     use super::super::*;
     use crate::styles::{CssClass, CssSource, IconPlace};
     use crate::{CurrentWidgetState, ExtendedUiConfiguration, ImageCache};
@@ -283,6 +283,33 @@ mod tests {
             window: Entity::PLACEHOLDER,
         };
         assert_eq!(wheel_delta_y(&pixel, 0.5), 15.0);
+    }
+
+    #[test]
+    fn wheel_delta_x_converts_line_and_pixel_units() {
+        let line_small = MouseWheel {
+            unit: MouseScrollUnit::Line,
+            x: 2.0,
+            y: 0.0,
+            window: Entity::PLACEHOLDER,
+        };
+        assert_eq!(wheel_delta_x(&line_small, 0.5), 50.0);
+
+        let line_big = MouseWheel {
+            unit: MouseScrollUnit::Line,
+            x: 12.0,
+            y: 0.0,
+            window: Entity::PLACEHOLDER,
+        };
+        assert_eq!(wheel_delta_x(&line_big, 0.5), 6.0);
+
+        let pixel = MouseWheel {
+            unit: MouseScrollUnit::Pixel,
+            x: 30.0,
+            y: 0.0,
+            window: Entity::PLACEHOLDER,
+        };
+        assert_eq!(wheel_delta_x(&pixel, 0.5), 15.0);
     }
 
     #[test]

--- a/src/widgets/unit_tests.rs
+++ b/src/widgets/unit_tests.rs
@@ -609,7 +609,7 @@ mod tests {
     fn choice_option_no_value_returns_none() {
         let opt = ChoiceOption {
             text: "empty".to_string(),
-            internal_value: None,
+            value: WidgetValue::default(),
             icon_path: None,
         };
 
@@ -678,7 +678,7 @@ mod tests {
     #[test]
     fn radio_button_value_as_str_only_for_string_values() {
         let string_rb = RadioButton {
-            value: Some(std::sync::Arc::new("option_a".to_string())),
+            value: WidgetValue::new("option_a".to_string()),
             ..RadioButton::default()
         };
         assert_eq!(string_rb.value_as_str(), Some("option_a"));
@@ -690,7 +690,7 @@ mod tests {
     #[test]
     fn radio_button_no_value_returns_none() {
         let rb = RadioButton {
-            value: None,
+            value: WidgetValue::default(),
             ..RadioButton::default()
         };
 

--- a/src/widgets/unit_tests.rs
+++ b/src/widgets/unit_tests.rs
@@ -137,7 +137,7 @@ mod tests {
     fn choice_option_new_trims_internal_value() {
         let option = ChoiceOption::new("  Hello World  ");
         assert_eq!(option.text, "  Hello World  ");
-        assert_eq!(option.internal_value, "Hello World");
+        assert_eq!(option.value_as_str(), Some("Hello World"));
         assert_eq!(option.icon_path, None);
     }
 
@@ -536,5 +536,166 @@ mod tests {
         app.insert_resource(ImageCache::default());
         app.init_asset::<Image>();
         app.add_plugins(ExtendedWidgetPlugin);
+    }
+
+    // ---------------------------------------------------------------
+    // Typed-value helpers shared by ChoiceOption and RadioButton
+    // ---------------------------------------------------------------
+
+    /// Enum used only inside these tests — no Reflect needed since we test
+    /// the plain `Arc<dyn Any>` path, not the Bevy-reflection path.
+    #[derive(Debug, PartialEq)]
+    enum Priority {
+        Low,
+        Medium,
+        High,
+    }
+
+    /// Arbitrary struct to cover the "object value" case.
+    #[derive(Debug, PartialEq)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    // --- ChoiceOption ---
+
+    #[test]
+    fn choice_option_with_integer_value() {
+        let opt = ChoiceOption::new("42").with_value(42_i32);
+
+        assert_eq!(opt.get_value::<i32>(), Some(&42_i32));
+        assert_eq!(opt.get_value::<u32>(), None); // wrong type
+        // value_as_str returns None because the Arc holds an i32, not a String
+        assert_eq!(opt.value_as_str(), None);
+    }
+
+    #[test]
+    fn choice_option_with_boolean_value() {
+        let opt_true = ChoiceOption::new("yes").with_value(true);
+        let opt_false = ChoiceOption::new("no").with_value(false);
+
+        assert_eq!(opt_true.get_value::<bool>(), Some(&true));
+        assert_eq!(opt_false.get_value::<bool>(), Some(&false));
+    }
+
+    #[test]
+    fn choice_option_with_enum_value() {
+        let opt = ChoiceOption::new("High").with_value(Priority::High);
+
+        assert_eq!(opt.get_value::<Priority>(), Some(&Priority::High));
+        assert_eq!(opt.get_value::<i32>(), None);
+    }
+
+    #[test]
+    fn choice_option_with_object_value() {
+        let opt = ChoiceOption::new("origin").with_value(Point { x: 0, y: 0 });
+
+        let p = opt.get_value::<Point>().expect("should downcast to Point");
+        assert_eq!(p.x, 0);
+        assert_eq!(p.y, 0);
+    }
+
+    #[test]
+    fn choice_option_value_as_str_only_for_string_values() {
+        let string_opt = ChoiceOption::new("hello");
+        assert_eq!(string_opt.value_as_str(), Some("hello"));
+
+        let int_opt = ChoiceOption::new("1").with_value(1_u32);
+        assert_eq!(int_opt.value_as_str(), None);
+    }
+
+    #[test]
+    fn choice_option_no_value_returns_none() {
+        let opt = ChoiceOption {
+            text: "empty".to_string(),
+            internal_value: None,
+            icon_path: None,
+        };
+
+        assert_eq!(opt.get_value::<i32>(), None);
+        assert_eq!(opt.value_as_str(), None);
+        assert!(opt.get_reflected().is_none());
+    }
+
+    #[test]
+    fn choice_option_partial_eq_compares_string_values() {
+        let a = ChoiceOption::new("foo");
+        let b = ChoiceOption::new("foo");
+        let c = ChoiceOption::new("bar");
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn choice_option_partial_eq_non_string_uses_ptr_identity() {
+        let opt_a = ChoiceOption::new("x").with_value(Priority::Low);
+        let opt_b = ChoiceOption::new("x").with_value(Priority::Low);
+        // Two independent Arcs holding equal values but different allocations.
+        assert_ne!(opt_a, opt_b);
+
+        // Cloning shares the Arc, so ptr_eq holds.
+        let opt_c = opt_a.clone();
+        assert_eq!(opt_a, opt_c);
+    }
+
+    // --- RadioButton ---
+
+    #[test]
+    fn radio_button_with_integer_value() {
+        let rb = RadioButton::default().with_value(7_i32);
+
+        assert_eq!(rb.get_value::<i32>(), Some(&7_i32));
+        assert_eq!(rb.get_value::<u8>(), None);
+        assert_eq!(rb.value_as_str(), None);
+    }
+
+    #[test]
+    fn radio_button_with_boolean_value() {
+        let rb = RadioButton::default().with_value(true);
+
+        assert_eq!(rb.get_value::<bool>(), Some(&true));
+    }
+
+    #[test]
+    fn radio_button_with_enum_value() {
+        let rb = RadioButton::default().with_value(Priority::Medium);
+
+        assert_eq!(rb.get_value::<Priority>(), Some(&Priority::Medium));
+        assert_eq!(rb.get_value::<bool>(), None);
+    }
+
+    #[test]
+    fn radio_button_with_object_value() {
+        let rb = RadioButton::default().with_value(Point { x: 3, y: -1 });
+
+        let p = rb.get_value::<Point>().expect("should downcast to Point");
+        assert_eq!(p.x, 3);
+        assert_eq!(p.y, -1);
+    }
+
+    #[test]
+    fn radio_button_value_as_str_only_for_string_values() {
+        let string_rb = RadioButton {
+            value: Some(std::sync::Arc::new("option_a".to_string())),
+            ..RadioButton::default()
+        };
+        assert_eq!(string_rb.value_as_str(), Some("option_a"));
+
+        let int_rb = RadioButton::default().with_value(99_i32);
+        assert_eq!(int_rb.value_as_str(), None);
+    }
+
+    #[test]
+    fn radio_button_no_value_returns_none() {
+        let rb = RadioButton {
+            value: None,
+            ..RadioButton::default()
+        };
+
+        assert_eq!(rb.get_value::<i32>(), None);
+        assert_eq!(rb.value_as_str(), None);
+        assert!(rb.get_reflected().is_none());
     }
 }

--- a/src/widgets/widget_util.rs
+++ b/src/widgets/widget_util.rs
@@ -1,15 +1,22 @@
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 
-pub fn wheel_delta_y(event: &MouseWheel, inv_scale_factor: f32) -> f32 {
-    match event.unit {
+fn wheel_delta_axis(value: f32, unit: MouseScrollUnit, inv_scale_factor: f32) -> f32 {
+    match unit {
         MouseScrollUnit::Line => {
-            let line_delta = event.y;
-            if line_delta.abs() > 10.0 {
-                line_delta * inv_scale_factor
+            if value.abs() > 10.0 {
+                value * inv_scale_factor
             } else {
-                line_delta * 25.0
+                value * 25.0
             }
         }
-        MouseScrollUnit::Pixel => event.y * inv_scale_factor,
+        MouseScrollUnit::Pixel => value * inv_scale_factor,
     }
+}
+
+pub fn wheel_delta_x(event: &MouseWheel, inv_scale_factor: f32) -> f32 {
+    wheel_delta_axis(event.x, event.unit, inv_scale_factor)
+}
+
+pub fn wheel_delta_y(event: &MouseWheel, inv_scale_factor: f32) -> f32 {
+    wheel_delta_axis(event.y, event.unit, inv_scale_factor)
 }


### PR DESCRIPTION
## Summary

This branch expands the crate in three main directions:

1. **new widget capabilities** (`typed values` support and a new `ListBox` control)
2. **correctness and UX fixes** across scrolling, selection, and CSS/widget behavior
3. **runtime performance improvements** in the HTML/CSS/style pipeline

It also updates the local/wasm examples and adds supporting documentation for architecture and performance notes.

---

## What changed

### 1) Typed values for selection widgets

**Related commits:** `0034105`, `26a88f0`

This branch adds a more flexible value model for option-based widgets.

- `ChoiceOption` now carries a `WidgetValue` instead of being limited to plain text-only semantics.
- Added helpers such as:
  - `with_value(...)`
  - `get_value::<T>()`
  - `value_as_str()`
  - reflected-value access for more advanced runtime recovery
- This enables `ChoiceBox` and related selection flows to store/recover richer payloads such as:
  - `String`
  - integers / floats
  - booleans
  - enum-like strings
  - reflected custom types

**Why this matters:**
It makes the widget API more ergonomic for real application state, where UI selections often represent typed domain values rather than display text.

---

### 2) New `ListBox` widget

**Related commits:** `ad7375e`

A new `ListBox` control was added to the widget set.

- Introduced a dedicated `ListBox` component/control implementation
- Supports:
  - **single-select** mode
  - **multi-select** mode
- Renders all options in a scrollable list, instead of hiding them behind a dropdown
- Integrates into:
  - widget registration
  - HTML bindings/change-event flow
  - crate styling/default widget setup

**Why this matters:**
This fills a common UI gap for cases where users should see and select from many options at once.

---

### 3) Example and demo updates

**Related commits:** `0034105`, `26a88f0`, `bef4548`, `480bb2f`, `072414e`

The example apps were expanded to demonstrate the new behavior and reduce friction when testing locally.

- Added a dedicated **typed values** example for both:
  - `crates/local-examples`
  - `crates/local-wasm-examples`
- Updated demo assets/CSS/HTML to better showcase the new selection behavior and widget coverage
- Improved the local example runner so you can choose a demo by CLI argument instead of editing `main.rs`

Examples can now be launched as:

```bash
cargo run --manifest-path crates/local-examples/Cargo.toml -- widget-overview
cargo run --manifest-path crates/local-examples/Cargo.toml -- theming-provider
cargo run --manifest-path crates/local-examples/Cargo.toml -- typed-values
```

**Why this matters:**
It makes the new APIs easier to validate and removes some local example maintenance friction.

---

### 4) Scroll and interaction bug fixes

**Related commits:** `5b16889`, `30b2c53`, `2ea0a84`, `46eb796`, `5778738`

This branch includes multiple fixes for widget/input behavior:

- fixed incorrect scroll event consumption behavior
- fixed nested `div` scrolling issues
- added **horizontal mouse-wheel scrolling** support where applicable
- added a **`Shift + vertical wheel => horizontal scroll`** fallback for devices that only emit vertical wheel deltas
- prevented paired thumb controls (e.g. range/scroll controls) from moving past each other or past their allowed bounds
- improved scroll-related state handling robustness in direct/test usage

**Why this matters:**
These changes make scrolling and range-selection behavior more predictable and much closer to expected desktop UI behavior.

---

### 5) CSS / styling / rendering correctness fixes

**Related commits:** `6819f5f`, `5778738`, `26a88f0`, `bef4548`, `480bb2f`

A set of cleanup fixes also landed across the HTML/CSS/widget pipeline:

- corrected CSS merging behavior for **dividers** and **scrollbars**
- fixed smaller ChoiceBox-related regressions/polish issues
- synced styling fixes across the wasm example assets
- cleaned up special-character issues in wasm example content/assets
- improved HTML/converter behavior around targeted rebuild tracking and relative asset handling

**Why this matters:**
This reduces visual inconsistencies and eliminates several edge-case regressions in the UI rendering path.

---

### 6) Performance optimizations

**Related commits:** `126594a`

This branch also contains a focused performance pass for the crate runtime.

Implemented improvements include:

- **dirty-gated inherited style propagation**
  - instead of re-walking more of the UI tree than necessary, style inheritance now targets dirty subtrees

- **indexed `BindToID` state propagation**
  - avoids repeatedly scanning all bound children when only a subset needs updates

- **narrowed CSS invalidation on viewport/media-query changes**
  - only entities tied to CSS assets whose media-match result changed are dirtied

- **selector metadata caching**
  - caches pseudo-state/specificity metadata so selector string work is not repeated on every refresh

- **targeted HTML rebuilds**
  - `HtmlDirty` now tracks which UI keys changed so the builder rebuilds only affected active roots instead of rebuilding everything

**Why this matters:**
Together, these changes reduce unnecessary ECS work in large or frequently restyled UIs and should make the crate feel smoother under dynamic updates.

---

## Key files / areas touched

| Area | Representative files |
| --- | --- |
| Typed values API | `src/widgets/mod.rs`, `src/widgets/controls/choice_box.rs` |
| New control widget | `src/widgets/controls/list_box.rs`, `src/widgets/controls/mod.rs` |
| HTML/bindings updates | `src/html/bindings.rs`, `src/html/converter.rs`, `src/html/builder.rs`, `src/html/mod.rs` |
| Performance work | `src/services/style_service.rs`, `src/services/state_service.rs`, `src/services/css_service.rs` |
| Scroll fixes | `src/widgets/body.rs`, `src/widgets/div.rs`, `src/widgets/widget_util.rs`, `src/widgets/controls/scroll_bar.rs`, `src/widgets/controls/slider.rs` |
| Examples | `crates/local-examples/*`, `crates/local-wasm-examples/*` |
| Tests | `src/html/unit_tests.rs`, `src/services/unit_tests.rs`, `src/widgets/unit_tests.rs` |

---

## Verification

Freshly verified on this branch with:

- `cargo test --lib` → **163 passed, 0 failed**
- `cargo check --all-targets`
- `cargo check --all-targets --all-features`
- `cargo run --manifest-path crates/local-examples/Cargo.toml --release -- --help`

The local examples binary also now builds cleanly through the help path without the previous dead-code warning noise.

---

## Reviewer notes

- This branch is mostly **additive + corrective** rather than a large breaking API rewrite.
- The most important review areas are:
  1. `ChoiceOption` / typed value behavior
  2. the new `ListBox` widget
  3. scroll handling changes
  4. the targeted performance optimizations in the service/html pipeline
