### PR TITLE
feat(widgets): add HTML table widget (table/tr/th/td)

### DIFF
--- a/CSS_USAGE.md
+++ b/CSS_USAGE.md
@@ -353,6 +353,16 @@ Tracks support:
 
 `grid-auto-rows` / `grid-auto-columns` accept a list of tracks (space-separated).
 
+### Tables
+
+`<table>` is a CSS Grid (`display: grid`), so it needs **no new properties** — the grid
+properties above already style it. The default column template is `repeat(N, 1fr)` where
+`N` is the widest row's cell count; set `grid-template-columns` on a `table` selector to
+override it. Style cells with `th`/`td` (or class/id) selectors. `<tr>` is flattened to a
+row index and has no entity, so it cannot be targeted by CSS. Cells inside `<thead>` /
+`<tbody>` / `<tfoot>` also get a matching `thead` / `tbody` / `tfoot` **class**, so target
+header/body/footer rows with `.thead`, `.tbody`, `.tfoot` (e.g. `.thead { font-weight: 700; }`).
+
 ## Media Queries (Breakpoints)
 
 `@media` rules are supported and are re-evaluated automatically when the configured viewport changes.

--- a/WIDGETS.md
+++ b/WIDGETS.md
@@ -72,6 +72,47 @@ When a child `<button type="submit">` is clicked, the form:
 
 ---
 
+## Table (`Table` / `TableCell`)
+
+**Struct purpose:** HTML-formatted table laid out as a CSS Grid. `Table` is the grid
+container and stores the auto-derived `columns` count (the widest row). Each `<th>`/`<td>`
+becomes a `TableCell` grid item carrying its zero-based `row`/`col`, a `header` flag, and
+its origin `section` (`Head`/`Body`/`Foot`).
+
+`<tr>` is **flattened**: it produces no entity. Instead, each cell is stamped with its
+row index and placed directly in the table grid via `grid_row`/`grid_column`. Cells are
+full containers — they may hold any nested widgets (text, button, img, div, …).
+
+The default column template is `repeat(N, 1fr)` (N = `columns`), applied after the style
+pass only when the author left `grid-template-columns` unset, so author CSS always wins.
+Section wrappers (`<thead>`/`<tbody>`/`<tfoot>`, plus the `<tbody>` the `kuchiki` HTML5
+parser implicitly wraps around bare `<tr>` rows) produce no entity, but each cell records which
+section it came from: its `TableCell.section` is set, and a matching CSS class
+(`thead`/`tbody`/`tfoot`) is stamped on the cell so author rules can target header,
+body, or footer rows (e.g. `.thead { font-weight: 700; }`, `td.tfoot { ... }`). Cells
+render in source order — sections are not reordered, and `colspan`/`rowspan` are not
+supported.
+
+**HTML tag:**
+```html
+<table>
+  <thead>
+    <tr><th>Name</th><th>Action</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Alice</td>
+      <td><button onclick="edit_row">Edit</button></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr><td>Total: 1</td><td></td></tr>
+  </tfoot>
+</table>
+```
+
+---
+
 ## Button (`Button`)
 
 **Struct purpose:** Clickable button with text plus an optional icon and its placement. Supports `type="button|submit|reset"` (`Auto` when omitted).

--- a/crates/local-examples/assets/examples/widget_overview.css
+++ b/crates/local-examples/assets/examples/widget_overview.css
@@ -89,6 +89,39 @@ body {
     gap: 10px;
 }
 
+.demo-table {
+    width: 100%;
+    gap: 4px;
+}
+
+.demo-table > th,
+.demo-table > td {
+    height: 34px;
+    border-radius: 6px;
+    background: #2a3247;
+    text-wrap: nowrap;
+}
+
+.demo-table > th {
+    background: #343d57;
+}
+
+.demo-table > .thead {
+    background: #3d4766;
+    color: #cdd6f4;
+}
+
+.demo-table > .tfoot {
+    background: #232a3d;
+    color: #8b93a7;
+}
+
+.demo-table > td > button {
+    width: 100%;
+    min-width: 0;
+    height: 28px;
+}
+
 .widget-card > form > input,
 .widget-card > form > button {
     width: 100%;

--- a/crates/local-examples/assets/examples/widgets_overview.html
+++ b/crates/local-examples/assets/examples/widgets_overview.html
@@ -260,6 +260,30 @@
   </div>
 
   <div class="widget-card">
+    <h5>Table</h5>
+    <table class="demo-table">
+      <thead>
+        <tr><th>Name</th><th>Role</th><th>Action</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Alice</td>
+          <td>Admin</td>
+          <td><button id="table-row-alice">Edit</button></td>
+        </tr>
+        <tr>
+          <td>Bob</td>
+          <td>Editor</td>
+          <td><button id="table-row-bob">Edit</button></td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr><td>2 users</td><td></td><td></td></tr>
+      </tfoot>
+    </table>
+  </div>
+
+  <div class="widget-card">
     <h5>Div</h5>
     <div class="demo-div">
       <p>Block A</p>

--- a/src/html/builder.rs
+++ b/src/html/builder.rs
@@ -27,6 +27,8 @@ enum HtmlNodeKindDiscriminant {
     Body,
     Div,
     Form,
+    Table,
+    TableCell,
     Dialog,
     Divider,
     Button,
@@ -501,6 +503,8 @@ macro_rules! preserve_entry {
 preserve_entry!(
     Body,
     crate::widgets::Form,
+    crate::widgets::Table,
+    crate::widgets::TableCell,
     crate::widgets::Button,
     crate::widgets::CheckBox,
     crate::widgets::ChoiceBox,
@@ -549,6 +553,12 @@ fn get_node_children(node: &HtmlWidgetNode) -> Option<&Vec<HtmlWidgetNode>> {
         return Some(children);
     }
     if let HtmlWidgetNode::FieldSet(_, _, _, children, _, _, _) = node {
+        return Some(children);
+    }
+    if let HtmlWidgetNode::Table(_, _, _, children, _, _, _) = node {
+        return Some(children);
+    }
+    if let HtmlWidgetNode::TableCell(_, _, _, children, _, _, _) = node {
         return Some(children);
     }
     #[cfg(feature = "extended-dialog")]
@@ -663,6 +673,32 @@ fn update_existing_widget_node(
                 commands,
                 entity,
                 form.clone(),
+                meta,
+                states,
+                functions,
+                widget,
+                id,
+                start_hidden,
+            );
+        }
+        HtmlWidgetNode::Table(table, meta, states, _, functions, widget, id) => {
+            update_with_meta(
+                commands,
+                entity,
+                table.clone(),
+                meta,
+                states,
+                functions,
+                widget,
+                id,
+                start_hidden,
+            );
+        }
+        HtmlWidgetNode::TableCell(cell, meta, states, _, functions, widget, id) => {
+            update_with_meta(
+                commands,
+                entity,
+                cell.clone(),
                 meta,
                 states,
                 functions,
@@ -1198,6 +1234,8 @@ fn get_node_id(node: &HtmlWidgetNode) -> &HtmlID {
         | HtmlWidgetNode::ListBox(_, _, _, _, _, id)
         | HtmlWidgetNode::Div(_, _, _, _, _, _, id)
         | HtmlWidgetNode::Form(_, _, _, _, _, _, id)
+        | HtmlWidgetNode::Table(_, _, _, _, _, _, id)
+        | HtmlWidgetNode::TableCell(_, _, _, _, _, _, id)
         | HtmlWidgetNode::FieldSet(_, _, _, _, _, _, id) => id,
         #[cfg(feature = "extended-dialog")]
         HtmlWidgetNode::Dialog(_, _, _, _, _, _, id) => id,
@@ -1209,6 +1247,8 @@ fn get_node_kind(node: &HtmlWidgetNode) -> HtmlNodeKind {
         HtmlWidgetNode::Body(..) => HtmlNodeKindDiscriminant::Body,
         HtmlWidgetNode::Div(..) => HtmlNodeKindDiscriminant::Div,
         HtmlWidgetNode::Form(..) => HtmlNodeKindDiscriminant::Form,
+        HtmlWidgetNode::Table(..) => HtmlNodeKindDiscriminant::Table,
+        HtmlWidgetNode::TableCell(..) => HtmlNodeKindDiscriminant::TableCell,
         #[cfg(feature = "extended-dialog")]
         HtmlWidgetNode::Dialog(..) => HtmlNodeKindDiscriminant::Dialog,
         HtmlWidgetNode::Divider(..) => HtmlNodeKindDiscriminant::Divider,
@@ -1389,6 +1429,14 @@ fn collect_html_ids(nodes: &Vec<HtmlWidgetNode>, ids: &mut Vec<HtmlID>) {
                 ids.push(id.clone());
                 collect_html_ids(children, ids);
             }
+            HtmlWidgetNode::Table(_, _, _, children, _, _, id) => {
+                ids.push(id.clone());
+                collect_html_ids(children, ids);
+            }
+            HtmlWidgetNode::TableCell(_, _, _, children, _, _, id) => {
+                ids.push(id.clone());
+                collect_html_ids(children, ids);
+            }
             HtmlWidgetNode::FieldSet(_, _, _, children, _, _, id) => {
                 ids.push(id.clone());
                 collect_html_ids(children, ids);
@@ -1512,6 +1560,52 @@ fn spawn_widget_node(
             let entity = spawn_with_meta(
                 commands,
                 form.clone(),
+                meta,
+                states,
+                functions,
+                widget,
+                id,
+                start_hidden,
+            );
+            for child in children {
+                let child_start_hidden = start_hidden;
+                spawn_widget_node(
+                    commands,
+                    child,
+                    asset_server,
+                    Some(entity),
+                    child_start_hidden,
+                );
+            }
+            entity
+        }
+        HtmlWidgetNode::Table(table, meta, states, children, functions, widget, id) => {
+            let entity = spawn_with_meta(
+                commands,
+                table.clone(),
+                meta,
+                states,
+                functions,
+                widget,
+                id,
+                start_hidden,
+            );
+            for child in children {
+                let child_start_hidden = start_hidden;
+                spawn_widget_node(
+                    commands,
+                    child,
+                    asset_server,
+                    Some(entity),
+                    child_start_hidden,
+                );
+            }
+            entity
+        }
+        HtmlWidgetNode::TableCell(cell, meta, states, children, functions, widget, id) => {
+            let entity = spawn_with_meta(
+                commands,
+                cell.clone(),
                 meta,
                 states,
                 functions,

--- a/src/html/converter.rs
+++ b/src/html/converter.rs
@@ -1751,8 +1751,168 @@ fn parse_html_node(
             ))
         }
 
+        "td" | "th" => {
+            let mut children = Vec::new();
+            for (index, child) in node.children().enumerate() {
+                let child_path = format!("{path}.{index}");
+                if let Some(parsed) = parse_html_node(
+                    &child,
+                    css_sources,
+                    label_map,
+                    key,
+                    html,
+                    raw_text_bindings,
+                    type_registry,
+                    child_path.as_str(),
+                ) {
+                    children.push(parsed);
+                }
+            }
+
+            // row/col default to 0 here; the enclosing `"table"` arm re-stamps the
+            // real grid coordinates. A bare cell outside a table is a valid 0,0 item.
+            Some(HtmlWidgetNode::TableCell(
+                TableCell {
+                    header: tag == "th",
+                    ..default()
+                },
+                meta,
+                states,
+                children,
+                functions,
+                widget.clone(),
+                node_id.clone(),
+            ))
+        }
+
+        "table" => {
+            let mut cells = Vec::new();
+            let mut columns = 0usize;
+            let mut row_idx = 0usize;
+
+            // The `kuchiki` HTML5 parser injects an implicit `<tbody>` (and honors
+            // any authored `<thead>`/`<tbody>`/`<tfoot>`) between `<table>` and its
+            // `<tr>` rows. Flatten those section wrappers so `<tr>` is found whether
+            // it sits directly under `<table>` or one level down inside a section,
+            // carrying the origin section so each cell can be tagged with it.
+            let rows = node.children().flat_map(|child| {
+                let section = child.as_element().and_then(|el| match &*el.name.local {
+                    "thead" => Some(TableSection::Head),
+                    "tbody" => Some(TableSection::Body),
+                    "tfoot" => Some(TableSection::Foot),
+                    _ => None,
+                });
+                match section {
+                    Some(section) => child.children().map(|tr| (section, tr)).collect::<Vec<_>>(),
+                    None => vec![(TableSection::Body, child)],
+                }
+            });
+
+            for (section, tr) in rows {
+                let Some(tr_el) = tr.as_element() else {
+                    continue;
+                };
+                if !tr_el.name.local.eq("tr") {
+                    continue;
+                }
+
+                let mut col_idx = 0usize;
+                for (index, cell) in tr.children().enumerate() {
+                    let Some(cell_el) = cell.as_element() else {
+                        continue;
+                    };
+                    let cell_name = cell_el.name.local.to_string();
+                    if cell_name != "td" && cell_name != "th" {
+                        continue;
+                    }
+
+                    let child_path = format!("{path}.{row_idx}.{index}");
+                    let Some(mut parsed) = parse_html_node(
+                        &cell,
+                        css_sources,
+                        label_map,
+                        key,
+                        html,
+                        raw_text_bindings,
+                        type_registry,
+                        child_path.as_str(),
+                    ) else {
+                        continue;
+                    };
+
+                    // Re-stamp the grid coordinates and origin section only the
+                    // table can know, and expose the section to CSS as a class.
+                    if let HtmlWidgetNode::TableCell(c, cell_meta, ..) = &mut parsed {
+                        c.row = row_idx;
+                        c.col = col_idx;
+                        c.section = section;
+                        let classes = cell_meta.class.get_or_insert_with(Vec::new);
+                        let section_class = section.css_class().to_string();
+                        if !classes.contains(&section_class) {
+                            classes.push(section_class);
+                        }
+                    }
+
+                    cells.push(parsed);
+                    col_idx += 1;
+                }
+
+                columns = columns.max(col_idx);
+                row_idx += 1;
+            }
+
+            Some(HtmlWidgetNode::Table(
+                Table {
+                    columns,
+                    ..default()
+                },
+                meta,
+                states,
+                cells,
+                functions,
+                widget.clone(),
+                node_id.clone(),
+            ))
+        }
+
         _ => None,
     }
+}
+
+/// Parses a standalone HTML fragment into its top-level [`HtmlWidgetNode`]s.
+///
+/// Wraps the fragment in a document, then runs [`parse_html_node`] on each direct
+/// child element of the resulting `<body>` with an empty CSS/label/binding context
+/// and a fresh [`TypeRegistry`]. Intended for parsing isolated snippets (e.g. a
+/// `<table>` subtree) without the full asset/runtime pipeline.
+pub fn parse_html_fragment(html: &str) -> Vec<HtmlWidgetNode> {
+    let document = kuchiki::parse_html().one(html);
+    let css_sources: Vec<Handle<CssAsset>> = Vec::new();
+    let label_map: HashMap<String, String> = HashMap::new();
+    let key = String::from("fragment");
+    let html_source = HtmlSource::from_handle(Handle::default());
+    let raw_text_bindings: HashMap<String, HtmlTextBinding> = HashMap::new();
+    let type_registry = TypeRegistry::default();
+
+    let Some(body) = select_primary_body_node(&document) else {
+        return Vec::new();
+    };
+
+    body.children()
+        .enumerate()
+        .filter_map(|(index, child)| {
+            parse_html_node(
+                &child,
+                &css_sources,
+                &label_map,
+                &key,
+                &html_source,
+                &raw_text_bindings,
+                &type_registry,
+                index.to_string().as_str(),
+            )
+        })
+        .collect()
 }
 
 /// Extracts HTML event bindings from element attributes.

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -29,7 +29,8 @@ use crate::styles::parser::apply_property_to_style;
 use crate::widgets::{
     Badge, Body, Button, CheckBox, ChoiceBox, ColorPicker, DatePicker, Div, Divider, FieldSet,
     Form, Headline, HyperLink, Img, InputField, ListBox, Paragraph, ProgressBar, RadioButton,
-    Scrollbar, Slider, SwitchButton, ToggleButton, ToolTip, ValidationRules, Widget,
+    Scrollbar, Slider, SwitchButton, Table, TableCell, ToggleButton, ToolTip, ValidationRules,
+    Widget,
 };
 
 pub static HTML_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
@@ -277,6 +278,38 @@ pub enum HtmlWidgetNode {
     Form(
         /// Variant `Form`.
         Form,
+        /// Variant `HtmlMeta`.
+        HtmlMeta,
+        /// Variant `HtmlStates`.
+        HtmlStates,
+        Vec<HtmlWidgetNode>,
+        /// Variant `HtmlEventBindings`.
+        HtmlEventBindings,
+        /// Variant `Widget`.
+        Widget,
+        /// Variant `HtmlID`.
+        HtmlID,
+    ),
+    /// A `<table>` grid container with cell child nodes.
+    Table(
+        /// Variant `Table`.
+        Table,
+        /// Variant `HtmlMeta`.
+        HtmlMeta,
+        /// Variant `HtmlStates`.
+        HtmlStates,
+        Vec<HtmlWidgetNode>,
+        /// Variant `HtmlEventBindings`.
+        HtmlEventBindings,
+        /// Variant `Widget`.
+        Widget,
+        /// Variant `HtmlID`.
+        HtmlID,
+    ),
+    /// A `<th>`/`<td>` table cell with nested child nodes.
+    TableCell(
+        /// Variant `TableCell`.
+        TableCell,
         /// Variant `HtmlMeta`.
         HtmlMeta,
         /// Variant `HtmlStates`.

--- a/src/old/registry.rs
+++ b/src/old/registry.rs
@@ -13,6 +13,8 @@ pub static UI_ID_GENERATE: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool:
 pub static BODY_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 pub static DIV_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 pub static FORM_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
+pub static TABLE_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
+pub static TABLE_CELL_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 pub static BUTTON_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 pub static CHECK_BOX_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
 pub static CHOICE_BOX_ID_POOL: Lazy<Mutex<IdPool>> = Lazy::new(|| Mutex::new(IdPool::new()));
@@ -576,6 +578,8 @@ fn despawn_widget_ids(
                 WidgetKind::Body => BODY_ID_POOL.lock().unwrap().release(widget_id.id),
                 WidgetKind::Div => DIV_ID_POOL.lock().unwrap().release(widget_id.id),
                 WidgetKind::Form => FORM_ID_POOL.lock().unwrap().release(widget_id.id),
+                WidgetKind::Table => TABLE_ID_POOL.lock().unwrap().release(widget_id.id),
+                WidgetKind::TableCell => TABLE_CELL_ID_POOL.lock().unwrap().release(widget_id.id),
                 WidgetKind::Headline => HEADLINE_ID_POOL.lock().unwrap().release(widget_id.id),
                 WidgetKind::HyperLink => HYPER_LINK_ID_POOL.lock().unwrap().release(widget_id.id),
                 WidgetKind::Paragraph => PARAGRAPH_ID_POOL.lock().unwrap().release(widget_id.id),

--- a/src/widgets/default_style.rs
+++ b/src/widgets/default_style.rs
@@ -148,6 +148,29 @@ fieldset {
     gap: 5px;
 }
 
+/* Table */
+
+table {
+    display: grid;
+    gap: 1px;
+    min-width: 200px;
+}
+
+th {
+    display: flex;
+    align-items: center;
+    padding: 6px 10px;
+    font-weight: 700;
+    color: var(--headline);
+}
+
+td {
+    display: flex;
+    align-items: center;
+    padding: 6px 10px;
+    color: var(--text-color);
+}
+
 /* Image */
 img {
     width: 100%;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -4,6 +4,7 @@ pub mod controls;
 pub(crate) mod default_style;
 pub mod div;
 mod form;
+pub mod table;
 pub mod validation;
 pub mod widget_util;
 
@@ -12,6 +13,7 @@ use crate::styles::IconPlace;
 use crate::widgets::body::BodyWidget;
 use crate::widgets::div::DivWidget;
 use crate::widgets::form::FormWidget;
+use crate::widgets::table::TableWidget;
 use bevy::prelude::*;
 use std::any::Any;
 use std::fmt;
@@ -19,6 +21,7 @@ use std::sync::Arc;
 
 pub use content::ExtendedContentWidgets;
 pub use controls::ExtendedControlWidgets;
+pub use table::{Table, TableCell, TableSection};
 pub use validation::evaluate_validation_state;
 
 /// Marker component for UI elements that should ignore the parent widget state.
@@ -213,6 +216,10 @@ pub enum WidgetKind {
     Divider,
     /// Variant `Form`.
     Form,
+    /// Variant `Table`.
+    Table,
+    /// Variant `TableCell`.
+    TableCell,
     /// Variant `FieldSet`.
     FieldSet,
     /// Variant `Headline`.
@@ -258,12 +265,16 @@ impl Plugin for ExtendedWidgetPlugin {
         app.register_type::<ValidationRules>();
         app.register_type::<Body>();
         app.register_type::<Form>();
+        app.register_type::<Table>();
+        app.register_type::<TableCell>();
+        app.register_type::<TableSection>();
         app.add_plugins((
             ExtendedControlWidgets,
             ExtendedContentWidgets,
             BodyWidget,
             DivWidget,
             FormWidget,
+            TableWidget,
         ));
         app.add_systems(Update, validation::update_validation_states);
     }

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -1,0 +1,241 @@
+use crate::ExtendedUiConfiguration;
+use crate::html::{HtmlInnerContent, HtmlSystemSet};
+use crate::old::registry::{TABLE_CELL_ID_POOL, TABLE_ID_POOL};
+use crate::services::style_service::update_widget_styles_system;
+use crate::styles::paint::Colored;
+use crate::styles::{CssSource, TagName};
+use crate::widgets::{UIGenID, UIWidgetState, Widget, WidgetId, WidgetKind};
+use bevy::camera::visibility::RenderLayers;
+use bevy::prelude::*;
+
+/// The `<table>` grid container.
+///
+/// `columns` is the auto-derived column count (the maximum number of cells in
+/// any single row), used as the default grid template by `apply_table_grid_system`.
+#[derive(Component, Reflect, Debug, Clone, PartialEq, Eq)]
+#[reflect(Component)]
+#[require(UIGenID, UIWidgetState, GlobalTransform, InheritedVisibility, Widget)]
+pub struct Table {
+    pub entry: usize,
+    pub columns: usize,
+}
+
+impl Default for Table {
+    fn default() -> Self {
+        let entry = TABLE_ID_POOL.lock().unwrap().acquire();
+        Self { entry, columns: 0 }
+    }
+}
+
+/// The table section a cell belongs to (`<thead>`/`<tbody>`/`<tfoot>`).
+///
+/// Section wrappers are flattened at parse time, so a cell carries its origin
+/// here instead. Each variant also maps to a CSS class (`thead`/`tbody`/`tfoot`)
+/// stamped on the cell so author rules can target header/body/footer rows.
+#[derive(Reflect, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TableSection {
+    /// A cell that came from `<thead>`.
+    Head,
+    /// A cell that came from `<tbody>`, or from a bare `<tr>` with no section.
+    #[default]
+    Body,
+    /// A cell that came from `<tfoot>`.
+    Foot,
+}
+
+impl TableSection {
+    /// The CSS class stamped on cells of this section.
+    pub fn css_class(self) -> &'static str {
+        match self {
+            TableSection::Head => "thead",
+            TableSection::Body => "tbody",
+            TableSection::Foot => "tfoot",
+        }
+    }
+}
+
+/// A `<th>` or `<td>` cell. Its position in the parent grid is fixed at parse time.
+#[derive(Component, Reflect, Debug, Clone, PartialEq, Eq)]
+#[reflect(Component)]
+#[require(UIGenID, UIWidgetState, GlobalTransform, InheritedVisibility, Widget)]
+pub struct TableCell {
+    pub entry: usize,
+    pub header: bool,
+    pub section: TableSection,
+    pub row: usize,
+    pub col: usize,
+}
+
+impl Default for TableCell {
+    fn default() -> Self {
+        let entry = TABLE_CELL_ID_POOL.lock().unwrap().acquire();
+        Self {
+            entry,
+            header: false,
+            section: TableSection::default(),
+            row: 0,
+            col: 0,
+        }
+    }
+}
+
+#[derive(Component)]
+struct TableBase;
+
+#[derive(Component)]
+struct TableCellBase;
+
+pub struct TableWidget;
+
+impl Plugin for TableWidget {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, internal_node_creation_system);
+        // Text cells are rendered after the build pass so a cell that hosts a
+        // child widget (e.g. `<td><button>`) already has its `Children` and is
+        // skipped — only childless text cells become `Text` nodes.
+        app.add_systems(Update, render_cell_text.after(HtmlSystemSet::Build));
+        // Grid values depend on the resolved style, so they must be written AFTER
+        // the style pass (which fully owns `Node`). `update_widget_styles_system`
+        // runs in `PostUpdate`; this system runs in the same schedule, after it.
+        app.add_systems(
+            PostUpdate,
+            apply_table_grid_system.after(update_widget_styles_system),
+        );
+    }
+}
+
+/// Inserts the base node for table and cell widgets.
+///
+/// Grid layout is deliberately NOT set here — a one-shot write is erased by the
+/// style pass. `display:grid` comes from `default_style.rs`; dynamic grid values
+/// come from [`apply_table_grid_system`].
+fn internal_node_creation_system(
+    mut commands: Commands,
+    table_query: Query<(Entity, &Table, Option<&CssSource>), (With<Table>, Without<TableBase>)>,
+    cell_query: Query<
+        (Entity, &TableCell, Option<&CssSource>),
+        (With<TableCell>, Without<TableCellBase>),
+    >,
+    config: Res<ExtendedUiConfiguration>,
+) {
+    let layer = *config.render_layers.first().unwrap_or(&1);
+
+    for (entity, table, source_opt) in table_query.iter() {
+        let css_source = source_opt.cloned().unwrap_or_default();
+
+        commands.entity(entity).insert((
+            Name::new(format!("Table-{}", table.entry)),
+            Node::default(),
+            WidgetId {
+                id: table.entry,
+                kind: WidgetKind::Table,
+            },
+            ImageNode::default(),
+            BackgroundColor::default(),
+            BorderColor::default(),
+            BoxShadow::new(
+                Colored::TRANSPARENT,
+                Val::Px(0.),
+                Val::Px(0.),
+                Val::Px(0.),
+                Val::Px(0.),
+            ),
+            ZIndex::default(),
+            Pickable::default(),
+            css_source,
+            TagName("table".to_string()),
+            RenderLayers::layer(layer),
+            TableBase,
+            UIWidgetState::default(),
+        ));
+    }
+
+    for (entity, cell, source_opt) in cell_query.iter() {
+        let css_source = source_opt.cloned().unwrap_or_default();
+        let tag = if cell.header { "th" } else { "td" };
+
+        commands.entity(entity).insert((
+            Name::new(format!("TableCell-{}", cell.entry)),
+            Node::default(),
+            WidgetId {
+                id: cell.entry,
+                kind: WidgetKind::TableCell,
+            },
+            ImageNode::default(),
+            BackgroundColor::default(),
+            BorderColor::default(),
+            BoxShadow::new(
+                Colored::TRANSPARENT,
+                Val::Px(0.),
+                Val::Px(0.),
+                Val::Px(0.),
+                Val::Px(0.),
+            ),
+            ZIndex::default(),
+            Pickable::default(),
+            css_source,
+            TagName(tag.to_string()),
+            RenderLayers::layer(layer),
+            TableCellBase,
+            UIWidgetState::default(),
+        ));
+    }
+}
+
+/// Renders a cell's inner text as a `Text` node.
+///
+/// A cell holds either nested widgets (e.g. `<td><button>`) or plain text. Only
+/// the plain-text case is handled here: cells that already have child entities
+/// are skipped (a `Text` entity cannot also lay out UI children), so a widget
+/// cell keeps its widgets and a text cell gets its text. Runs after the build
+/// pass so a widget cell's `Children` is already present.
+fn render_cell_text(
+    mut commands: Commands,
+    query: Query<
+        (Entity, &HtmlInnerContent),
+        (With<TableCellBase>, Without<Text>, Without<Children>),
+    >,
+) {
+    for (entity, content) in query.iter() {
+        let text = content.inner_text().trim();
+        if text.is_empty() {
+            continue;
+        }
+        commands.entity(entity).insert((
+            Text::new(text.to_string()),
+            TextColor::default(),
+            TextFont::default(),
+            TextLayout::default(),
+        ));
+    }
+}
+
+/// Writes the dynamic grid values the style pass cannot know, only when the
+/// author left them unset so author CSS always wins.
+///
+/// Runs in `PostUpdate` after `update_widget_styles_system`, which rewrites every
+/// `Node` field from the resolved style. An author `grid-template-columns` leaves
+/// `Node.grid_template_columns` non-empty after that pass → skip. An author cell
+/// `grid-row`/`grid-column` leaves it `!= GridPlacement::DEFAULT` → skip.
+fn apply_table_grid_system(
+    mut table_query: Query<(&Table, &mut Node), With<TableBase>>,
+    mut cell_query: Query<(&TableCell, &mut Node), (With<TableCellBase>, Without<Table>)>,
+) {
+    for (table, mut node) in table_query.iter_mut() {
+        if node.grid_template_columns.is_empty() {
+            // `columns.max(1)` keeps the empty-table case a valid single-track grid.
+            node.grid_template_columns =
+                vec![RepeatedGridTrack::flex(table.columns.max(1) as u16, 1.0)];
+        }
+    }
+
+    for (cell, mut node) in cell_query.iter_mut() {
+        // `+1`: grid lines are 1-indexed; `GridPlacement::start(0)` panics.
+        if node.grid_column == GridPlacement::DEFAULT {
+            node.grid_column = GridPlacement::start((cell.col + 1) as i16);
+        }
+        if node.grid_row == GridPlacement::DEFAULT {
+            node.grid_row = GridPlacement::start((cell.row + 1) as i16);
+        }
+    }
+}

--- a/tests/src/html/converter_test.rs
+++ b/tests/src/html/converter_test.rs
@@ -1,12 +1,240 @@
 #[cfg(test)]
 mod tests {
+    use super::super::HtmlWidgetNode;
     use super::super::converter::{
-        extract_inner_bindings, parse_inner_content, preprocess_template_directives,
-        preprocess_template_directives_with_shared,
+        extract_inner_bindings, parse_html_fragment, parse_inner_content,
+        preprocess_template_directives, preprocess_template_directives_with_shared,
         preprocess_template_directives_with_shared_and_local_types,
     };
     use crate::lang::{UiLangVariables, UiSharedValues};
     use kuchiki::traits::TendrilSink;
+
+    /// Returns the cells of the first parsed `Table` node, asserting the fragment
+    /// produced exactly one table and no stray top-level `<tr>` nodes.
+    fn table_cells(html: &str) -> (usize, Vec<(bool, usize, usize, String)>) {
+        let nodes = parse_html_fragment(html);
+        let tables: Vec<&HtmlWidgetNode> = nodes
+            .iter()
+            .filter(|n| matches!(n, HtmlWidgetNode::Table(..)))
+            .collect();
+        assert_eq!(tables.len(), 1, "expected exactly one Table node");
+
+        let HtmlWidgetNode::Table(table, _, _, cells, _, _, _) = tables[0] else {
+            unreachable!()
+        };
+
+        // <tr> is flattened: every direct table child must be a TableCell, never a
+        // row node. `parse_html_node` returns `None` for `<tr>`, so a row node could
+        // not appear here — this assertion locks that contract.
+        let parsed = cells
+            .iter()
+            .map(|cell| {
+                let HtmlWidgetNode::TableCell(c, meta, _, _, _, _, _) = cell else {
+                    panic!("table child was not a TableCell: {cell:?}");
+                };
+                (
+                    c.header,
+                    c.row,
+                    c.col,
+                    meta.inner_content.inner_text().trim().to_string(),
+                )
+            })
+            .collect();
+
+        (table.columns, parsed)
+    }
+
+    /// Returns the raw `TableCell` nodes of the single table in `html` (cells kept
+    /// as `HtmlWidgetNode` so callers can inspect their children).
+    fn first_table_cells(html: &str) -> Vec<HtmlWidgetNode> {
+        let nodes = parse_html_fragment(html);
+        let table = nodes
+            .into_iter()
+            .find(|n| matches!(n, HtmlWidgetNode::Table(..)))
+            .expect("expected a Table node");
+        let HtmlWidgetNode::Table(_, _, _, cells, _, _, _) = table else {
+            unreachable!()
+        };
+        cells
+    }
+
+    #[test]
+    fn parse_cell_marks_header_flag() {
+        // A bare `<td>`/`<th>` is foster-parented away by the HTML5 parser, so the
+        // `td|th` arm is reached only inside a table — exercise it there.
+        let cells = first_table_cells("<table><tr><td>Hi</td><th>Yo</th></tr></table>");
+        assert_eq!(cells.len(), 2);
+        match (&cells[0], &cells[1]) {
+            (
+                HtmlWidgetNode::TableCell(data, _, _, _, _, _, _),
+                HtmlWidgetNode::TableCell(header, _, _, _, _, _, _),
+            ) => {
+                assert!(!data.header);
+                assert_eq!((data.row, data.col), (0, 0));
+                assert!(header.header);
+                assert_eq!((header.row, header.col), (0, 1));
+            }
+            other => panic!("expected two TableCells, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cell_with_nested_button_keeps_child_node() {
+        let cells = first_table_cells(
+            r#"<table><tr><td><button onclick="go">X</button></td></tr></table>"#,
+        );
+        match &cells[0] {
+            HtmlWidgetNode::TableCell(_, _, _, children, _, _, _) => {
+                assert_eq!(children.len(), 1);
+                assert!(matches!(children[0], HtmlWidgetNode::Button(..)));
+            }
+            other => panic!("expected TableCell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_table_2x3_yields_six_cells_and_three_columns() {
+        let html = r#"
+            <table>
+                <tr><th>A</th><th>B</th><th>C</th></tr>
+                <tr><td>1</td><td>2</td><td>3</td></tr>
+            </table>
+        "#;
+        let (columns, cells) = table_cells(html);
+        assert_eq!(columns, 3, "column count is the widest row");
+        assert_eq!(cells.len(), 6);
+
+        // Row 0 is the header row, row 1 data; indices stamped per cell.
+        assert_eq!(
+            cells,
+            vec![
+                (true, 0, 0, "A".to_string()),
+                (true, 0, 1, "B".to_string()),
+                (true, 0, 2, "C".to_string()),
+                (false, 1, 0, "1".to_string()),
+                (false, 1, 1, "2".to_string()),
+                (false, 1, 2, "3".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_table_text_only_cell_exposes_inner_content() {
+        let (_, cells) = table_cells("<table><tr><td>Hello</td></tr></table>");
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].3, "Hello");
+    }
+
+    #[test]
+    fn parse_table_skips_whitespace_between_rows_and_cells() {
+        // Newlines/spaces between <tr> and between <td> must not create cells.
+        let html = "<table>\n  <tr>\n    <td>1</td>\n    <td>2</td>\n  </tr>\n</table>";
+        let (columns, cells) = table_cells(html);
+        assert_eq!(columns, 2);
+        assert_eq!(cells.len(), 2, "whitespace must not become cells");
+    }
+
+    #[test]
+    fn parse_table_ignores_stray_non_structural_tags() {
+        // A stray non-<tr> child of <table>, and a stray non-cell child of <tr>.
+        let html = r#"
+            <table>
+                <div>ignored</div>
+                <tr><td>1</td><span>nope</span><td>2</td></tr>
+            </table>
+        "#;
+        let (columns, cells) = table_cells(html);
+        assert_eq!(columns, 2, "stray tags do not count as cells");
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].3, "1");
+        assert_eq!(cells[1].3, "2");
+        assert_eq!(cells[1].2, 1, "second cell keeps col index 1");
+    }
+
+    #[test]
+    fn parse_table_ragged_rows_keep_max_columns_and_own_indices() {
+        let html = r#"
+            <table>
+                <tr><td>a</td><td>b</td><td>c</td></tr>
+                <tr><td>d</td><td>e</td></tr>
+            </table>
+        "#;
+        let (columns, cells) = table_cells(html);
+        assert_eq!(columns, 3, "widest row sets the column count");
+        assert_eq!(cells.len(), 5);
+        // Row 1's two cells sit at col 0 and 1; col 2 is simply unoccupied.
+        assert_eq!(cells[3], (false, 1, 0, "d".to_string()));
+        assert_eq!(cells[4], (false, 1, 1, "e".to_string()));
+    }
+
+    #[test]
+    fn parse_table_stamps_section_and_class_from_wrappers() {
+        use crate::widgets::TableSection;
+
+        let html = r#"
+            <table>
+                <thead><tr><th>H</th></tr></thead>
+                <tbody><tr><td>B</td></tr></tbody>
+                <tfoot><tr><td>F</td></tr></tfoot>
+            </table>
+        "#;
+        let cells = first_table_cells(html);
+        assert_eq!(cells.len(), 3);
+
+        let section_and_class: Vec<(TableSection, Vec<String>)> = cells
+            .iter()
+            .map(|cell| {
+                let HtmlWidgetNode::TableCell(c, meta, _, _, _, _, _) = cell else {
+                    panic!("expected TableCell, got {cell:?}");
+                };
+                (c.section, meta.class.clone().unwrap_or_default())
+            })
+            .collect();
+
+        assert_eq!(section_and_class[0].0, TableSection::Head);
+        assert!(section_and_class[0].1.contains(&"thead".to_string()));
+        assert_eq!(section_and_class[1].0, TableSection::Body);
+        assert!(section_and_class[1].1.contains(&"tbody".to_string()));
+        assert_eq!(section_and_class[2].0, TableSection::Foot);
+        assert!(section_and_class[2].1.contains(&"tfoot".to_string()));
+    }
+
+    #[test]
+    fn parse_table_bare_rows_default_to_body_section() {
+        use crate::widgets::TableSection;
+
+        // A `<tr>` directly under `<table>` (implicit tbody) is the Body section,
+        // and its class carries `tbody`.
+        let cells = first_table_cells("<table><tr><td>x</td></tr></table>");
+        let HtmlWidgetNode::TableCell(c, meta, _, _, _, _, _) = &cells[0] else {
+            panic!("expected TableCell");
+        };
+        assert_eq!(c.section, TableSection::Body);
+        assert!(
+            meta.class
+                .clone()
+                .unwrap_or_default()
+                .contains(&"tbody".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_table_section_class_preserves_author_classes() {
+        use crate::widgets::TableSection;
+
+        let cells =
+            first_table_cells(r#"<table><thead><tr><th class="hd">H</th></tr></thead></table>"#);
+        let HtmlWidgetNode::TableCell(c, meta, _, _, _, _, _) = &cells[0] else {
+            panic!("expected TableCell");
+        };
+        assert_eq!(c.section, TableSection::Head);
+        let classes = meta.class.clone().unwrap_or_default();
+        assert!(classes.contains(&"hd".to_string()), "author class kept");
+        assert!(
+            classes.contains(&"thead".to_string()),
+            "section class added"
+        );
+    }
 
     #[test]
     fn extract_inner_bindings_returns_unique_placeholders() {

--- a/tests/src/html/html_test.rs
+++ b/tests/src/html/html_test.rs
@@ -18,8 +18,8 @@ mod tests {
     use crate::widgets::{
         BadgeAnchor, Body, Button, ButtonType, DateFormat, FieldMode, FormValidationMode,
         HyperLinkBrowsers, InputCap, InputField, InputType, Paragraph, RadioButton, Scrollbar,
-        Slider, SliderDotAnchor, SliderType, SwitchButton, ToggleButton, ToolTipAlignment,
-        ToolTipPriority, ToolTipTrigger, ToolTipVariant, UIWidgetState, Widget,
+        Slider, SliderDotAnchor, SliderType, SwitchButton, Table, TableCell, ToggleButton,
+        ToolTipAlignment, ToolTipPriority, ToolTipTrigger, ToolTipVariant, UIWidgetState, Widget,
     };
     use bevy::asset::{AssetEvent, AssetPlugin};
     use bevy::ecs::message::Messages;
@@ -1265,6 +1265,214 @@ mod tests {
         assert!(entity_ref.contains::<UIWidgetState>());
 
         assert!(!app.world().entities().contains(old_body));
+    }
+
+    fn table_fixture() -> &'static str {
+        r##"
+        <html>
+          <head>
+            <meta name="table-key" />
+          </head>
+          <body>
+            <table>
+              <tr><th>Name</th><th>Action</th></tr>
+              <tr>
+                <td>Alice</td>
+                <td><button onclick="row_click">Go</button></td>
+              </tr>
+            </table>
+          </body>
+        </html>
+        "##
+    }
+
+    /// Drives the converter + builder over a real table fixture and asserts the
+    /// spawned entity tree: one `Table`, its cells are direct `TableCell` children
+    /// (so `<tr>` produced no row entity — it was flattened), a text-only cell keeps
+    /// its `HtmlInnerContent`, and an in-cell `<button onclick>` keeps its
+    /// `Button` + `HtmlEventBindings`.
+    #[test]
+    fn builder_spawns_table_tree_with_cells_and_nested_widget() {
+        let mut app = setup_converter_app();
+        app.add_message::<HtmlAllWidgetsSpawned>();
+        app.add_systems(Update, builder::build_html_source);
+        app.init_resource::<HtmlPendingReveal>();
+
+        add_html_source(
+            &mut app,
+            "examples/table_fixture.html",
+            table_fixture(),
+            "table-key",
+            None,
+        );
+
+        app.update();
+        {
+            let mut map = app.world_mut().resource_mut::<HtmlStructureMap>();
+            map.active = Some(vec!["table-key".to_string()]);
+        }
+        app.world_mut().resource_mut::<HtmlDirty>().0 = true;
+        app.update();
+
+        let world = app.world_mut();
+
+        // Exactly one Table entity.
+        let mut table_q = world.query::<(Entity, &Table)>();
+        let tables: Vec<Entity> = table_q.iter(world).map(|(e, _)| e).collect();
+        assert_eq!(tables.len(), 1, "exactly one Table entity");
+        let table_entity = tables[0];
+
+        // Its direct children are all TableCell — `<tr>` is flattened, so no row
+        // entity sits between the table and its cells.
+        let children: Vec<Entity> = world
+            .get::<Children>(table_entity)
+            .map(|c| c.iter().collect())
+            .unwrap_or_default();
+        assert_eq!(
+            children.len(),
+            4,
+            "2 header + 2 data cells are direct children"
+        );
+        for child in &children {
+            assert!(
+                world.get::<TableCell>(*child).is_some(),
+                "every direct table child is a TableCell, never a row node"
+            );
+        }
+
+        // No entity in the whole world is a row: there is no Tr component/variant,
+        // and the only TableCell parents are the table — assert cell count is 4.
+        let mut cell_q = world.query::<&TableCell>();
+        assert_eq!(cell_q.iter(world).count(), 4);
+
+        // The text-only data cell ("Alice") exposes its text via HtmlInnerContent.
+        let mut text_cell_q = world.query::<(&TableCell, &HtmlInnerContent)>();
+        let has_alice = text_cell_q
+            .iter(world)
+            .any(|(_, inner)| inner.inner_text().trim() == "Alice");
+        assert!(has_alice, "text cell keeps its inner content");
+
+        // The in-cell <button onclick> kept its Button + HtmlEventBindings.
+        let mut button_q = world.query::<(&Button, &HtmlEventBindings)>();
+        let buttons: Vec<String> = button_q
+            .iter(world)
+            .filter_map(|(_, bind)| bind.onclick.clone())
+            .collect();
+        assert!(
+            buttons.iter().any(|name| name == "row_click"),
+            "nested button preserved its onclick binding inside the cell"
+        );
+    }
+
+    /// A table-free asset spawns no table entities and still builds.
+    #[test]
+    fn builder_leaves_table_free_asset_without_table_entities() {
+        let mut app = setup_converter_app();
+        app.add_message::<HtmlAllWidgetsSpawned>();
+        app.add_systems(Update, builder::build_html_source);
+        app.init_resource::<HtmlPendingReveal>();
+
+        add_html_source(
+            &mut app,
+            "examples/no_table.html",
+            html_fixture(),
+            "meta-key",
+            None,
+        );
+
+        app.update();
+        {
+            let mut map = app.world_mut().resource_mut::<HtmlStructureMap>();
+            map.active = Some(vec!["meta-key".to_string()]);
+        }
+        app.world_mut().resource_mut::<HtmlDirty>().0 = true;
+        app.update();
+
+        let world = app.world_mut();
+        let mut table_q = world.query::<&Table>();
+        assert_eq!(table_q.iter(world).count(), 0, "no Table entities");
+        let mut cell_q = world.query::<&TableCell>();
+        assert_eq!(cell_q.iter(world).count(), 0, "no TableCell entities");
+        // The unrelated widgets still built (sanity that the build ran at all).
+        let mut body_q = world.query::<&Body>();
+        assert_eq!(body_q.iter(world).count(), 1);
+    }
+
+    /// Rebuilding the active UI with a structurally larger table diffs the
+    /// tree in place through the reconcile path: the converter re-parses the modified
+    /// asset into the SAME key, the builder reconciles the existing Body tree (reusing
+    /// matching cells, spawning the added row's cells), and no stale cells remain.
+    #[test]
+    fn rebuild_reconciles_table_when_a_row_is_added() {
+        let mut app = setup_converter_app();
+        app.add_message::<HtmlAllWidgetsSpawned>();
+        app.add_systems(Update, builder::build_html_source);
+        app.init_resource::<HtmlPendingReveal>();
+
+        let two_row = r##"
+        <html><head><meta name="rk" /></head>
+          <body><table>
+            <tr><td>a</td><td>b</td></tr>
+            <tr><td>c</td><td>d</td></tr>
+          </table></body>
+        </html>"##;
+        let handle = add_html_source(&mut app, "examples/recon.html", two_row, "rk", None);
+
+        app.update();
+        {
+            let mut map = app.world_mut().resource_mut::<HtmlStructureMap>();
+            map.active = Some(vec!["rk".to_string()]);
+        }
+        app.world_mut().resource_mut::<HtmlDirty>().0 = true;
+        app.update();
+
+        let world = app.world_mut();
+        let mut cell_q = world.query::<&TableCell>();
+        assert_eq!(cell_q.iter(world).count(), 4, "2x2 table → 4 cells");
+
+        // Modify the asset to a 3-row table and notify the converter; it re-parses
+        // the same "rk" key into a fresh Body tree, then the builder reconciles.
+        let three_row = r##"
+        <html><head><meta name="rk" /></head>
+          <body><table>
+            <tr><td>a</td><td>b</td></tr>
+            <tr><td>c</td><td>d</td></tr>
+            <tr><td>e</td><td>f</td></tr>
+          </table></body>
+        </html>"##;
+        app.world_mut()
+            .resource_mut::<Assets<HtmlAsset>>()
+            .insert(
+                handle.id(),
+                HtmlAsset {
+                    html: three_row.to_string(),
+                    stylesheets: Vec::new(),
+                },
+            )
+            .expect("replace HtmlAsset");
+        app.world_mut()
+            .resource_mut::<Messages<AssetEvent<HtmlAsset>>>()
+            .write(AssetEvent::Modified { id: handle.id() });
+
+        // One update re-parses (converter) + sets the active key dirty; a second
+        // update lets the builder reconcile the now-dirty active tree.
+        app.update();
+        {
+            let mut map = app.world_mut().resource_mut::<HtmlStructureMap>();
+            map.active = Some(vec!["rk".to_string()]);
+        }
+        app.world_mut().resource_mut::<HtmlDirty>().0 = true;
+        app.update();
+
+        let world = app.world_mut();
+        let mut cell_q2 = world.query::<&TableCell>();
+        assert_eq!(
+            cell_q2.iter(world).count(),
+            6,
+            "after reconcile the added row's 2 cells exist (6 total), none stale"
+        );
+        let mut table_q = world.query::<&Table>();
+        assert_eq!(table_q.iter(world).count(), 1, "still exactly one table");
     }
 
     #[test]

--- a/tests/src/widgets/mod.rs
+++ b/tests/src/widgets/mod.rs
@@ -5,4 +5,5 @@ pub use bevy_extended_ui::widgets::widget_util;
 pub use bevy_extended_ui::widgets::*;
 
 mod body_test;
+mod table_test;
 mod widgets_test;

--- a/tests/src/widgets/table_test.rs
+++ b/tests/src/widgets/table_test.rs
@@ -1,0 +1,268 @@
+#[cfg(test)]
+mod tests {
+    use crate::ExtendedUiConfiguration;
+    use crate::styles::TagName;
+    use crate::widgets::table::TableWidget;
+    use crate::widgets::{Table, TableCell, WidgetId, WidgetKind};
+    use bevy::camera::visibility::RenderLayers;
+    use bevy::prelude::*;
+
+    /// Builds a headless App with only the real `TableWidget` plugin (init system
+    /// in `Update`, grid system in `PostUpdate`). No render-heavy `StyleService`: a
+    /// freshly spawned entity's `Node` already matches the post-style default state
+    /// (empty grid template, `GridPlacement::DEFAULT`), so `apply_table_grid_system`
+    /// exercises the same branch it would after the style pass.
+    fn widget_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(ExtendedUiConfiguration::default());
+        app.add_plugins(TableWidget);
+        app
+    }
+
+    /// Runs enough frames that both the `Update` init system and the `PostUpdate`
+    /// grid system execute against the spawned entities.
+    fn run_frames(app: &mut App, frames: usize) {
+        for _ in 0..frames {
+            app.update();
+        }
+    }
+
+    #[test]
+    fn table_init_attaches_base_components_and_tag() {
+        let mut app = widget_app();
+        let table = app
+            .world_mut()
+            .spawn(Table {
+                columns: 2,
+                ..default()
+            })
+            .id();
+        run_frames(&mut app, 2);
+
+        let world = app.world();
+        // Base styling components — these come from
+        // `internal_node_creation_system`, NOT `spawn_with_meta`, so CSS can target them.
+        assert!(world.get::<BackgroundColor>(table).is_some());
+        assert!(world.get::<BorderColor>(table).is_some());
+        assert!(world.get::<ZIndex>(table).is_some());
+        assert!(world.get::<Pickable>(table).is_some());
+        assert!(world.get::<RenderLayers>(table).is_some());
+
+        let tag = world.get::<TagName>(table).expect("table TagName");
+        assert_eq!(tag.0, "table");
+
+        let wid = world.get::<WidgetId>(table).expect("table WidgetId");
+        assert!(matches!(wid.kind, WidgetKind::Table));
+    }
+
+    #[test]
+    fn cell_tag_reflects_header_flag() {
+        let mut app = widget_app();
+        let header = app
+            .world_mut()
+            .spawn(TableCell {
+                header: true,
+                row: 0,
+                col: 0,
+                ..default()
+            })
+            .id();
+        let data = app
+            .world_mut()
+            .spawn(TableCell {
+                header: false,
+                row: 0,
+                col: 1,
+                ..default()
+            })
+            .id();
+        run_frames(&mut app, 2);
+
+        let world = app.world();
+        assert_eq!(world.get::<TagName>(header).unwrap().0, "th");
+        assert_eq!(world.get::<TagName>(data).unwrap().0, "td");
+        assert!(matches!(
+            world.get::<WidgetId>(data).unwrap().kind,
+            WidgetKind::TableCell
+        ));
+    }
+
+    #[test]
+    fn grid_system_fills_template_and_cell_placement() {
+        let mut app = widget_app();
+        let table = app
+            .world_mut()
+            .spawn(Table {
+                columns: 3,
+                ..default()
+            })
+            .id();
+        let cell = app
+            .world_mut()
+            .spawn(TableCell {
+                header: false,
+                row: 1,
+                col: 2,
+                ..default()
+            })
+            .id();
+        run_frames(&mut app, 2);
+
+        let world = app.world();
+        let table_node = world.get::<Node>(table).expect("table Node");
+        assert!(
+            !table_node.grid_template_columns.is_empty(),
+            "auto column template must be applied when author left it unset"
+        );
+
+        let cell_node = world.get::<Node>(cell).expect("cell Node");
+        // 1-based: row 1 -> start(2), col 2 -> start(3).
+        assert_eq!(cell_node.grid_row, GridPlacement::start(2));
+        assert_eq!(cell_node.grid_column, GridPlacement::start(3));
+    }
+
+    #[test]
+    fn empty_table_gets_single_track_without_panic() {
+        let mut app = widget_app();
+        let table = app
+            .world_mut()
+            .spawn(Table {
+                columns: 0,
+                ..default()
+            })
+            .id();
+        run_frames(&mut app, 2);
+
+        // `columns.max(1)` keeps a zero-column table a valid single-track grid.
+        let node = app.world().get::<Node>(table).expect("table Node");
+        assert_eq!(node.grid_template_columns.len(), 1);
+    }
+
+    #[test]
+    fn author_template_is_not_overwritten_by_grid_system() {
+        // Author CSS path: the post-style `Node` already carries a non-empty
+        // `grid_template_columns`. The grid system must see it non-empty and skip
+        // the auto `repeat(N, 1fr)` default so the author value wins.
+        let mut app = widget_app();
+        let table = app
+            .world_mut()
+            .spawn(Table {
+                columns: 3,
+                ..default()
+            })
+            .id();
+        // Let the init system attach the base Node first.
+        app.update();
+        // Simulate the resolved author style: 2 explicit tracks on the Node.
+        {
+            let mut node = app.world_mut().get_mut::<Node>(table).unwrap();
+            node.grid_template_columns = vec![
+                RepeatedGridTrack::px(1, 80.0),
+                RepeatedGridTrack::flex(1, 1.0),
+            ];
+        }
+        app.update();
+
+        let node = app.world().get::<Node>(table).unwrap();
+        assert_eq!(
+            node.grid_template_columns.len(),
+            2,
+            "author template (2 tracks) survives; auto repeat(3) is skipped"
+        );
+    }
+
+    #[test]
+    fn grid_is_reapplied_after_a_node_reset() {
+        // Clobber regression (the bug review caught): the style pass rewrites every
+        // `Node` field via `unwrap_or_default()` each dirty frame, erasing the grid.
+        // Because `apply_table_grid_system` runs AFTER the style pass every frame, a
+        // reset `Node` must be re-patched on the next update.
+        let mut app = widget_app();
+        let table = app
+            .world_mut()
+            .spawn(Table {
+                columns: 2,
+                ..default()
+            })
+            .id();
+        let cell = app
+            .world_mut()
+            .spawn(TableCell {
+                row: 0,
+                col: 1,
+                ..default()
+            })
+            .id();
+        app.update();
+        app.update();
+        assert!(
+            !app.world()
+                .get::<Node>(table)
+                .unwrap()
+                .grid_template_columns
+                .is_empty()
+        );
+
+        // Reproduce `apply_style_to_node`'s clobber: reset the grid fields to their
+        // post-style defaults (empty template, DEFAULT placement).
+        {
+            let mut t_node = app.world_mut().get_mut::<Node>(table).unwrap();
+            t_node.grid_template_columns = Vec::new();
+        }
+        {
+            let mut c_node = app.world_mut().get_mut::<Node>(cell).unwrap();
+            c_node.grid_column = GridPlacement::DEFAULT;
+            c_node.grid_row = GridPlacement::DEFAULT;
+        }
+        app.update();
+
+        let world = app.world();
+        assert!(
+            !world
+                .get::<Node>(table)
+                .unwrap()
+                .grid_template_columns
+                .is_empty(),
+            "table grid template restored after reset"
+        );
+        assert_eq!(
+            world.get::<Node>(cell).unwrap().grid_column,
+            GridPlacement::start(2),
+            "cell placement restored after reset"
+        );
+    }
+
+    #[test]
+    fn ragged_cells_keep_their_own_column_indices() {
+        let mut app = widget_app();
+        // Row 1 of a ragged table: two cells at col 0 and col 1; col 2 stays empty.
+        let c0 = app
+            .world_mut()
+            .spawn(TableCell {
+                row: 1,
+                col: 0,
+                ..default()
+            })
+            .id();
+        let c1 = app
+            .world_mut()
+            .spawn(TableCell {
+                row: 1,
+                col: 1,
+                ..default()
+            })
+            .id();
+        run_frames(&mut app, 2);
+
+        let world = app.world();
+        assert_eq!(
+            world.get::<Node>(c0).unwrap().grid_column,
+            GridPlacement::start(1)
+        );
+        assert_eq!(
+            world.get::<Node>(c1).unwrap().grid_column,
+            GridPlacement::start(2)
+        );
+    }
+}


### PR DESCRIPTION
Thanks for the library, it is awesome, I am evaluating it for a new project.

Here is a PR for https://github.com/exepta/bevy_extended_ui/issues/201 . 

Transparency note: it was AI assisted, but I reviewed it all and guided changes.

I'm still learning and any feedback is welcome.

It was actually looking for a data grid, but table seems to address static data.